### PR TITLE
Fix lanczos artefacts

### DIFF
--- a/joerd/output/skadi.py
+++ b/joerd/output/skadi.py
@@ -114,7 +114,8 @@ class Skadi:
         dst_ds.SetProjection(dst_srs.ExportToWkt())
         dst_ds.GetRasterBand(1).SetNoDataValue(-32768)
 
-        composite.compose(self.sources, dst_ds, dst_bbox, logger)
+        composite.compose(self.sources, dst_ds, dst_bbox, logger,
+                          min(dst_x_res, dst_y_res))
 
         logger.info("Writing SRTMHGT: %r" % outfile)
         srtm_drv = gdal.GetDriverByName("SRTMHGT")

--- a/joerd/output/terrarium.py
+++ b/joerd/output/terrarium.py
@@ -162,7 +162,14 @@ class Terrarium:
         dst_ds.SetProjection(dst_srs.ExportToWkt())
         dst_ds.GetRasterBand(1).SetNoDataValue(-32768)
 
-        composite.compose(self.sources, dst_ds, dst_bbox, logger)
+        # figure out what the approximate scale of the output image is in
+        # lat/lon coordinates. this is used to select the appropriate filter.
+        ll_bbox = _latlon_bbox(z, x, y)
+        ll_x_res = float(ll_bbox.bounds[2] - ll_bbox.bounds[0]) / dst_x_size
+        ll_y_res = float(ll_bbox.bounds[3] - ll_bbox.bounds[1]) / dst_y_size
+
+        composite.compose(self.sources, dst_ds, dst_bbox, logger,
+                          min(ll_x_res, ll_y_res))
 
         mem_drv = gdal.GetDriverByName("MEM")
         mem_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, gdal.GDT_UInt16)

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -79,7 +79,7 @@ class ETOPO1:
     def mask_negative(self):
         return False
 
-    def filter_type(self):
+    def filter_type(self, src_res, dst_res):
         return gdal.GRA_Lanczos
 
 

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -138,8 +138,8 @@ class GMTED:
     def mask_negative(self):
         return True
 
-    def filter_type(self):
-        return gdal.GRA_Lanczos
+    def filter_type(self, src_res, dst_res):
+        return gdal.GRA_Lanczos if src_res > dst_res else gdal.GRA_Cubic
 
     def _parse_bbox(self, ns_deg, is_ns, ew_deg, is_ew, res):
         bottom = int(ns_deg)

--- a/joerd/source/ned.py
+++ b/joerd/source/ned.py
@@ -149,8 +149,8 @@ class NED:
     def mask_negative(self):
         return False
 
-    def filter_type(self):
-        return gdal.GRA_Lanczos
+    def filter_type(self, src_res, dst_res):
+        return gdal.GRA_Lanczos if src_res > dst_res else gdal.GRA_Cubic
 
     def _intersects(self, bbox):
         for r in self.regions:

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -128,7 +128,7 @@ class NEDBase(object):
         return gdal.GRA_Lanczos if src_res > dst_res else gdal.GRA_Cubic
 
     def vrt_file(self):
-        return os.path.join(self.base_path, self.vrt_filename)
+        return os.path.join(self.base_dir, self.vrt_filename)
 
     def _intersects(self, bbox):
         for r in self.regions:

--- a/joerd/source/srtm.py
+++ b/joerd/source/srtm.py
@@ -136,8 +136,8 @@ class SRTM:
     def mask_negative(self):
         return True
 
-    def filter_type(self):
-        return gdal.GRA_Lanczos
+    def filter_type(self, src_res, dst_res):
+        return gdal.GRA_Lanczos if src_res > dst_res else gdal.GRA_Cubic
 
     def _parse_bbox(self, is_ns, ns_deg, is_ew, ew_deg):
         bottom = int(ns_deg)


### PR DESCRIPTION
The Lanczos filter is great for really smooth interpolation, but it doesn't matter as much when reducing the resolution of a data source. It also has the problem that it's susceptible to "ringing", or producing particularly light or dark artefact pixels near the edges of the interpolation.

This changes most of the data sources to flip to cubic interpolation when the source resolution is greater than the destination resolution, which should stop most of these artefacts.

Connects to #12.

@rmarianski could you review, please?