### PR TITLE
Make downloads more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 build/
 dist/
 joerd.egg-info/
-*.egg/
+/*.egg/
+/*.egg
 
 # data directories
 srtm/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 build/
 dist/
 joerd.egg-info/
+*.egg/
 
 # data directories
 srtm/

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -23,6 +23,7 @@ sources:
     url: http://edcintl.cr.usgs.gov/downloads/sciweb1/shared/topo/downloads/GMTED/Global_tiles_GMTED
     ys: [-90, -70, -50, -30, -10, 10, 30, 50, 70]
     xs: [-180, -150, -120, -90, -60, -30, 0, 30, 60, 90, 120, 150]
+    tries: 100
   - type: srtm
     url: http://e4ftl01.cr.usgs.gov/SRTM/SRTMGL1.003/2000.02.11/
   - type: ned

--- a/joerd/check.py
+++ b/joerd/check.py
@@ -1,0 +1,37 @@
+import zipfile
+from osgeo import gdal
+
+
+def is_zip(tmp):
+    """
+    Returns True if the NamedTemporaryFile given as the argument appears to be
+    a well-formed Zip file.
+    """
+
+    try:
+        zip_file = zipfile.ZipFile(tmp.name, 'r')
+        test_result = zip_file.testzip()
+        return test_result is None
+
+    except:
+        pass
+
+    return False
+
+
+def is_gdal(tmp):
+    """
+    Returns true if the NamedTemporaryFile given as the argument appears to be
+    a well-formed GDAL raster file.
+    """
+
+    try:
+        ds = gdal.Open(tmp.name)
+        band = ds.GetRasterBand(1)
+        band.ComputeBandStats()
+        return True
+
+    except:
+        pass
+
+    return False

--- a/joerd/download.py
+++ b/joerd/download.py
@@ -105,7 +105,12 @@ def get(url, options={}):
 
             # try to get the filesize, if the server reports it.
             if filesize is None:
-                filesize = int(f.info().get('Content-Length'))
+                content_length = f.info().get('Content-Length')
+                if content_length is not None:
+                    try:
+                        filesize = int(content_length)
+                    except ValueError:
+                        pass
 
             # detect whether the server accepts Range requests.
             accept_range = f.info().get('Accept-Ranges') == 'bytes'

--- a/joerd/download.py
+++ b/joerd/download.py
@@ -1,17 +1,108 @@
 from contextlib import contextmanager, closing
-import requests
+import urllib2
 import tempfile
 import os
+import logging
+import shutil
 
 
 @contextmanager
 def get(url, options={}):
+    """
+    Download a file to a temporary directory, returning it.
+
+    The options provided will control the behaviour of the download algorithm.
+
+      * 'tries' - The maximum number of tries to download the file before
+        giving up and raising an exception.
+      * 'timeout' - Timeout in seconds before considering the connection to
+        have failed.
+      * 'verifier' - A function which is called with a filelike object. It
+        should return True if the file is okay and appears to be fully
+        downloaded.
+    """
     with closing(tempfile.NamedTemporaryFile()) as tmp:
-        with closing(requests.get(url, stream=True)) as req:
-            for chunk in req.iter_content(chunk_size=10240):
-                if chunk:
-                    tmp.write(chunk)
-        tmp.flush()
+        # current file position = number of bytes read
+        filepos = 0
+
+        # file size when downloaded, if known
+        filesize = None
+
+        # number of attempts so far
+        tries = 0
+
+        # maximum number of attempts to make
+        max_tries = options.get('tries', 1)
+
+        # timeout for blocking operations (e.g: connect) in seconds
+        timeout = options.get('timeout', 60)
+
+        # verifier function
+        verifier = options.get('verifier')
+
+        # whether the server supports Range headers (if it doesn't we'll have
+        # to restart from the beginning every time).
+        accept_range = False
+
+        # we need to download _something_ if the file position is less than the
+        # known size, or the size is unknown.
+        while filesize is None or filepos < filesize:
+            req = urllib2.Request(url)
+
+            # if the server supports accept range, and we have a partial
+            # download then attemp to resume it.
+            if accept_range and filepos > 0:
+                assert filesize is not None
+                req.headers['Range'] = 'bytes=%s-%s' % (filepos, filesize - 1)
+            else:
+                # otherwise, truncate the file in readiness to download from
+                # scratch.
+                filepos = 0
+                tmp.seek(0, os.SEEK_SET)
+                tmp.truncate(0)
+
+            f = urllib2.urlopen(req, timeout=timeout)
+
+            # try to get the filesize, if the server reports it.
+            if filesize is None:
+                filesize = int(f.info().get('Content-Length'))
+
+            # detect whether the server accepts Range requests.
+            accept_range = f.info().get('Accept-Ranges') == 'bytes'
+
+            # copy data from the server
+            shutil.copyfileobj(f, tmp)
+
+            # update number of bytes read (this would be nicer if copyfileobj
+            # returned it.
+            filepos = tmp.tell()
+            tries += 1
+
+            # if we don't know how large the file is supposed to be, then
+            # verify it every time.
+            if filesize is None and verifier is not None:
+                # reset tmp file to beginning for verification
+                tmp.seek(0, os.SEEK_SET)
+                if verifier(tmp):
+                    break
+                # no need to reset here - since filesize is none, then we'll be
+                # downloading from scratch, which will truncate the file.
+
+            # explode if we've exceeded the number of allowed attempts
+            if tries > max_tries:
+                break
+
+        if tries > max_tries:
+            raise Exception("Max tries exceeded (%d) while downloading file %r"
+                            % (max_tries, url))
+
+        # verify the file, if it hasn't been verified before
+        if filesize is not None and verifier is not None:
+            # reset tmp file to beginning for verification
+            tmp.seek(0, os.SEEK_SET)
+            if not verifier(tmp):
+                raise Exception("File downloaded from %r failed verification"
+                                % url)
 
         tmp.seek(0, os.SEEK_SET)
-        yield tmp.file
+        yield tmp

--- a/joerd/download.py
+++ b/joerd/download.py
@@ -1,0 +1,17 @@
+from contextlib import contextmanager, closing
+import requests
+import tempfile
+import os
+
+
+@contextmanager
+def get(url, options={}):
+    with closing(tempfile.NamedTemporaryFile()) as tmp:
+        with closing(requests.get(url, stream=True)) as req:
+            for chunk in req.iter_content(chunk_size=10240):
+                if chunk:
+                    tmp.write(chunk)
+        tmp.flush()
+
+        tmp.seek(0, os.SEEK_SET)
+        yield tmp.file

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -1,4 +1,5 @@
 from joerd.util import BoundingBox
+from joerd.download import get as joerd_get
 from contextlib import closing
 from shutil import copyfile
 import os.path
@@ -13,6 +14,7 @@ import traceback
 import subprocess
 import glob
 from osgeo import gdal
+from time import sleep
 
 
 WGS84_WKT = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,' \
@@ -22,19 +24,31 @@ WGS84_WKT = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,' \
             '"EPSG","9108"]],AUTHORITY["EPSG","4326"]]'
 
 
+def _check_zip_file(tmp):
+    try:
+        zip_file = zipfile.ZipFile(tmp.name, 'r')
+        test_result = zip_file.testzip()
+        return test_result is None
+
+    except:
+        pass
+
+    return False
+
+
+def _exponential_backoff(try_num):
+    secs = min((1 << try_num) - 1, 600)
+    sleep(secs)
+
+
 def _download_etopo1_file(target_name, base_dir, url):
     output_file = os.path.join(base_dir, target_name)
 
     if os.path.isfile(output_file):
         return output_file
 
-    with closing(tempfile.NamedTemporaryFile()) as tmp:
-        with closing(requests.get(url, stream=True)) as req:
-            for chunk in req.iter_content(chunk_size=10240):
-                if chunk:
-                    tmp.write(chunk)
-        tmp.flush()
-
+    with joerd_get(url, dict(verifier=_check_zip_file, tries=10,
+                             backoff=_exponential_backoff)) as tmp:
         with zipfile.ZipFile(tmp.name, 'r') as zfile:
             zfile.extract(target_name, base_dir)
 

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -35,7 +35,8 @@ def __download_gmted_file(x, y, base_dir, base_url, options):
 
     options['verifier'] = check.is_gdal
     with download.get(url, options) as tmp:
-        copyfileobj(tmp, open(output_file, 'w'))
+        with open(output_file, 'w') as out:
+            copyfileobj(tmp, out)
 
     return output_file
 

--- a/logging.example.config
+++ b/logging.example.config
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,srtm,skadi,gmted,etopo1,terrarium,ned
+keys=root,srtm,skadi,gmted,etopo1,terrarium,ned,download
 
 [handlers]
 keys=consoleHandler
@@ -44,6 +44,12 @@ propagate=0
 [logger_terrarium]
 level=INFO
 qualname=terrarium
+handlers=consoleHandler
+propagate=0
+
+[logger_download]
+level=INFO
+qualname=download
 handlers=consoleHandler
 propagate=0
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name='joerd',
       ],
       test_suite='tests',
       tests_require=[
+          'httptestserver',
       ],
       entry_points=dict(
           console_scripts=[

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,48 @@
+import unittest
+import joerd.download as download
+try:
+    # Python 2.x
+    import BaseHTTPServer as http
+except ImportError:
+    # Python 3.x
+    from http import server as http
+import contextlib
+from httptestserver import Server
+
+
+class _SimpleHandler(http.BaseHTTPRequestHandler):
+    def __init__(self, value, *args):
+        self.value = value
+        http.BaseHTTPRequestHandler.__init__(self, *args)
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Length', len(self.value))
+        self.end_headers()
+        self.wfile.write(self.value)
+
+
+# guard function to run a test HTTP server on another thread and reap it when
+# it goes out of scope.
+@contextlib.contextmanager
+def _test_http_server(handler):
+    server = Server('127.0.0.1', 0, 'http', handler)
+    server.start()
+    yield server
+
+
+class TestDownload(unittest.TestCase):
+
+    def test_download_simple(self):
+        value = "Some random string here."
+
+        def _handler(*args):
+            return _SimpleHandler(value, *args)
+
+        def _verifier(filelike):
+            return filelike.read() == value
+
+        with _test_http_server(_handler) as server:
+            with download.get(server.url('/'), dict(
+                    verifier=_verifier, tries=1)) as data:
+                self.assertEqual(value, data.read())

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -8,8 +8,12 @@ except ImportError:
     from http import server as http
 import contextlib
 from httptestserver import Server
+import re
+import sys
 
 
+# simple handler which does what most HTTP servers (should) do; responds with
+# the whole requested file.
 class _SimpleHandler(http.BaseHTTPRequestHandler):
     def __init__(self, value, *args):
         self.value = value
@@ -20,6 +24,58 @@ class _SimpleHandler(http.BaseHTTPRequestHandler):
         self.send_header('Content-Length', len(self.value))
         self.end_headers()
         self.wfile.write(self.value)
+
+
+# handler which emulates the GMTED server / TCP-layer rate-limiter; it drops
+# connections after some number of bytes.
+class _DroppingHandler(http.BaseHTTPRequestHandler):
+    def __init__(self, value, max_len, *args):
+        self.value = value
+        self.max_len = max_len
+        http.BaseHTTPRequestHandler.__init__(self, *args)
+
+    def _parse_range(self, r):
+        if r is None:
+            return None
+
+        m = re.match('bytes=([0-9]+)-([0-9]*)', r)
+        if not m:
+            return None
+
+        start = int(m.group(1))
+        end = int(m.group(2)) if len(m.group(2)) > 0 else None
+
+        if end is None:
+            end = min(start + self.max_len, len(self.value))
+        else:
+            end = min(end, start + self.max_len, len(self.value))
+
+        return (start, end)
+
+    def do_GET(self):
+        byte_range = self._parse_range(self.headers.get('Range'))
+
+        if byte_range is None:
+            self.send_response(200)
+            self.send_header('Accept-Ranges', 'bytes')
+            self.send_header('Content-Length', len(self.value))
+            self.end_headers()
+            self.wfile.write(self.value[0:self.max_len])
+
+        elif byte_range[0] >= len(self.value):
+            self.send_response(416)
+            self.send_header('Accept-Ranges', 'bytes')
+            self.end_headers()
+
+        else:
+            cr = 'bytes %d-%d/%d' % \
+                 (byte_range[0], len(self.value) - 1, len(self.value))
+            self.send_response(206)
+            self.send_header('Accept-Ranges', 'bytes')
+            self.send_header('Content-Length', len(self.value) - byte_range[0])
+            self.send_header('Content-Range', cr)
+            self.end_headers()
+            self.wfile.write(self.value[byte_range[0]:byte_range[1]+1])
 
 
 # guard function to run a test HTTP server on another thread and reap it when
@@ -45,4 +101,19 @@ class TestDownload(unittest.TestCase):
         with _test_http_server(_handler) as server:
             with download.get(server.url('/'), dict(
                     verifier=_verifier, tries=1)) as data:
+                self.assertEqual(value, data.read())
+
+    def test_download_restart(self):
+        value = "Some random string here."
+
+        def _handler(*args):
+            return _DroppingHandler(value, 4, *args)
+
+        def _verifier(filelike):
+            v = filelike.read() == value
+            return v
+
+        with _test_http_server(_handler) as server:
+            with download.get(server.url('/'), dict(
+                    verifier=_verifier, tries=(len(value) / 4 + 1))) as data:
                 self.assertEqual(value, data.read())


### PR DESCRIPTION
Some download sites (e.g: the GMTED one) have a TCP-layer rate-limiter which simply kills connections. This makes it rather difficult to download large files reliably, which would be required if running Joerd across a large cluster.

This PR adds a download method which is reliable in the sense that it can resume terminated downloads, and is configurable.

Connects to #18.

@rmarianski could you review, please?