### PR TITLE
Huge refactor. Adds zoom ranges to source selections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,14 @@ dist/
 joerd.egg-info/
 /*.egg/
 /*.egg
+/.eggs
 
 # data directories
 srtm/
 gmted/
 etopo1/
 ned/
+ned_topobathy/
 
 # tile generation directories
 tiles/

--- a/README.md
+++ b/README.md
@@ -48,19 +48,17 @@ python setup.py install
 Using
 -----
 
-Joerd installs as a command line library, and there are currently three commands:
+Joerd installs as a command line library, and there is currently only one command:
 
-* `download` reads the regions of interest from your config file and downloads all the sources to satisfy requests in that region. This is a prerequisite for the other steps.
-* `buildvrt` builds a [VRT](http://www.gdal.org/gdal_vrttut.html) "virtual dataset" of all the downloaded files. This requires that you have already run `download`, and is a prerequisite of the `generate` step.
-* `generate` generates all the configured outputs matching your regions of interest.
+* `process` reads the regions of interest from your config file, downloads all the sources to satisfy requests in that region, and for each tile intersecting the regions of interest in configured outputs, builds a [VRT](http://www.gdal.org/gdal_vrttut.html) "virtual dataset" of all relevant source files and generates the output image(s).
 
-To run each command, type something like this:
+To run a command, type something like this:
 
 ```sh
 joerd <command> --config config.example.yaml
 ```
 
-Where `<command>` is one of the commands above. The config has four sections:
+Where `<command>` is one of the commands above (currently only `process`). The config has five sections:
 
 * `regions` is a map of named sections, each with a `bbox` section having `top`, `left`, `bottom` and `right` coordinates. These describe the bounding box of the region. Data from the sources will be downloaded to cover that region, and outputs within it will be generated.
 * `outputs` is a list of output plugins. Currently available:
@@ -71,6 +69,9 @@ Where `<command>` is one of the commands above. The config has four sections:
   * `gmted` downloads data from GMTED, a global topology dataset at 30 or 15 arc-seconds.
   * `srtm` downloads data from SRTM, an almost-global 3 arc-second topology dataset.
 * `logging` has a single section, `config`, which gives the location of a Python logging config file.
+* `jobs` controls how Joerd runs jobs. The defaults are reasonable, so this whole section may be omitted. Current subsections are:
+  * `num_threads` is how many threads to use when downloading files or generating output images. Defaults to the number of CPUs on the host computer.
+  * `chunksize` is how many jobs to assign to a single thread at once. The default is a heuristic which tries to balance large chunk size for greater throughput and small chunk size for better load balance.
 
 License
 -------

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,8 @@ regions:
 outputs:
   - type: skadi
   - type: terrarium
-    zooms: [9, 10, 11, 12, 13]
+    zooms: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    enable_browser_png: true
 sources:
   - type: etopo1
     url: https://www.ngdc.noaa.gov/mgg/global/relief/ETOPO1/data/bedrock/grid_registered/georeferenced_tiff/ETOPO1_Bed_g_geotiff.zip
@@ -26,9 +27,10 @@ sources:
     tries: 100
   - type: srtm
     url: http://e4ftl01.cr.usgs.gov/SRTM/SRTMGL1.003/2000.02.11/
-  - type: ned
-    ftp_server: rockyftp.cr.usgs.gov
-    base_path: vdelivery/Datasets/Staged/NED/19/IMG
+  # disable, until https://github.com/mapzen/joerd/issues/3 is sorted out
+  # - type: ned
+  #   ftp_server: rockyftp.cr.usgs.gov
+  #   base_path: vdelivery/Datasets/Staged/NED/19/IMG
   - type: ned_topobathy
     ftp_server: rockyftp.cr.usgs.gov
     base_path: vdelivery/Datasets/Staged/NED/19/IMG

--- a/joerd/command.py
+++ b/joerd/command.py
@@ -2,9 +2,11 @@ from config import make_config_from_argparse
 from osgeo import gdal
 from importlib import import_module
 from multiprocessing import Pool
+import joerd.download as download
 import sys
 import argparse
 import os
+import os.path
 import logging
 import logging.config
 
@@ -18,9 +20,18 @@ def create_command_parser(fn):
     return create_parser_fn
 
 
-def _mktile(t):
-    output, tile = t
-    output.process_tile(tile)
+def _download(d):
+    options = d.options().copy()
+    options['verifier'] = d.verifier()
+
+    with download.get(d.url(), options) as tmp:
+        d.unpack(tmp)
+
+    assert os.path.isfile(d.output_file())
+
+
+def _render(t):
+    t.render()
 
 
 class Joerd:
@@ -28,28 +39,75 @@ class Joerd:
     def __init__(self, cfg):
         self.sources = self._sources(cfg)
         self.outputs = self._outputs(cfg, self.sources)
+        self.num_threads = cfg.num_threads
+        self.chunksize = cfg.chunksize
 
-    def download(self):
+    def process(self):
+        logger = logging.getLogger('process')
+
+        # fetch index for each source, which speeds up subsequent downloads or
+        # queries about which source tiles are available.
         for source in self.sources:
-            source.download()
+            source.get_index()
 
-    def buildvrt(self):
-        for source in self.sources:
-            source.buildvrt()
-
-    def generate(self):
+        # get the list of all tiles to be generated
         tiles = []
-
         for output in self.outputs:
-            tiles.extend([(output, t) for t in output.generate_tiles()])
+            tiles.extend(output.generate_tiles())
 
-        p = Pool()
-        try:
-            p.map(_mktile, tiles)
+        logger.info("Will generate %d tiles." % len(tiles))
 
-        finally:
-            p.close()
-            p.join()
+        # gather the set of all downloads - upstream source tiles - for all the
+        # tiles that will be generated.
+        downloads = set()
+        for tile in tiles:
+            # each tile intersects a set of downloads for each source, perhaps
+            # an empty set. to track those, only sources which intersect the
+            # tile are tracked.
+            tile_sources = []
+            for source in self.sources:
+                d = source.downloads_for(tile)
+                if d:
+                    downloads.update(d)
+                    tile_sources.append(source)
+            tile.set_sources(tile_sources)
+
+        p = Pool(processes=self.num_threads)
+
+        # grab a list of the files which aren't currently available
+        need_to_download = []
+        for download in downloads:
+            if not os.path.isfile(download.output_file()):
+                need_to_download.append(download)
+
+        logger.info("Need to download %d source files."
+                    % len(need_to_download))
+
+        p.map(_download, need_to_download,
+              chunksize=self._chunksize(len(need_to_download)))
+
+        logger.info("Starting render of %d tiles." % len(tiles))
+
+        # now render the tiles
+        p.map(_render, tiles, chunksize=self._chunksize(len(tiles)))
+
+        # clean up the Pool.
+        p.close()
+        p.join()
+
+    def _chunksize(self, length):
+        """
+        Try to determine an appropriate chunk size. The bigger the chunk, the
+        lower the overheads, but potentially worse load balance between the
+        different threads. A compromise is a fixed fraction of the maximum
+        chunk size - in this case, an eighth.
+
+        Chunksize can be overridden in the config, in which case this
+        heuristic is ignored.
+        """
+        if self.chunksize is not None:
+              return self.chunksize
+        return max(1, length / self.num_threads / 8)
 
     def _sources(self, cfg):
         sources = []
@@ -77,19 +135,9 @@ class JoerdArgumentParser(argparse.ArgumentParser):
         sys.exit(2)
 
 
-def joerd_download(cfg):
+def joerd_process(cfg):
     j = Joerd(cfg)
-    j.download()
-
-
-def joerd_buildvrt(cfg):
-    j = Joerd(cfg)
-    j.buildvrt()
-
-
-def joerd_generate(cfg):
-    j = Joerd(cfg)
-    j.generate()
+    j.process()
 
 
 def joerd_main(argv=None):
@@ -100,9 +148,7 @@ def joerd_main(argv=None):
     subparsers = parser.add_subparsers()
 
     parser_config = (
-        ('download', create_command_parser(joerd_download)),
-        ('buildvrt', create_command_parser(joerd_buildvrt)),
-        ('generate', create_command_parser(joerd_generate)),
+        ('process', create_command_parser(joerd_process)),
     )
 
     for name, func in parser_config:

--- a/joerd/command.py
+++ b/joerd/command.py
@@ -115,7 +115,7 @@ class Joerd:
             source_type = source['type']
             module = import_module('joerd.source.%s' % source_type)
             create_fn = getattr(module, 'create')
-            sources.append(create_fn(cfg.regions, source))
+            sources.append(create_fn(source))
         return sources
 
     def _outputs(self, cfg, sources):

--- a/joerd/composite.py
+++ b/joerd/composite.py
@@ -105,7 +105,6 @@ def compose(tile, dst_ds, dst_bbox, logger, dst_res):
         def _filter_type_func(src_res):
             return source.filter_type(src_res, dst_res)
 
-        # TODO!
         rasters = source.downloads_for(tile)
         with vrt.build([r.output_file() for r in rasters],
                        source.srs().ExportToWkt()) as src_ds:

--- a/joerd/composite.py
+++ b/joerd/composite.py
@@ -1,3 +1,4 @@
+from joerd import vrt
 from osgeo import osr, gdal
 import numpy
 import numpy.ma
@@ -22,21 +23,8 @@ def _tx_bbox(tx, bbox, expand=0.0):
             bbox[3] + 0.5 * expand * yspan)
 
 
-def _mk_image(infile, dst_ds, dst_bbox, mask_negative, filter_type):
-    src_ds = gdal.Open(infile)
-
-    src_srs = osr.SpatialReference()
+def _mk_image(src_ds, dst_ds, mask_negative, filter_type):
     src_srs_wkt = src_ds.GetProjection()
-    assert src_srs_wkt, "Need a valid source SRS, not %r" % src_srs_wkt
-    src_srs.ImportFromWkt(src_srs_wkt)
-    dst_srs = osr.SpatialReference()
-    dst_srs_wkt = dst_ds.GetProjection()
-    assert dst_srs_wkt, "Need a valid destination SRS, not %r" % dst_srs_wkt
-    dst_srs.ImportFromWkt(dst_srs_wkt)
-
-    rev_tx = osr.CoordinateTransformation(dst_srs, src_srs)
-    src_bbox = _tx_bbox(rev_tx, dst_bbox, 0.1)
-
     src_gt = src_ds.GetGeoTransform()
     src_x_res = abs(src_gt[1])
     src_y_res = abs(src_gt[5])
@@ -44,15 +32,16 @@ def _mk_image(infile, dst_ds, dst_bbox, mask_negative, filter_type):
     src_band = src_ds.GetRasterBand(1)
     src_nodata = src_band.GetNoDataValue()
 
-    f_type = filter_type(min(src_x_res, src_y_res))
-    res = gdal.ReprojectImage(src_ds, dst_ds, src_srs.ExportToWkt(),
-                              dst_srs.ExportToWkt(), f_type, 1024, 0.125)
-    assert res == gdal.CPLE_None
-
     dst_x_size = dst_ds.RasterXSize
     dst_y_size = dst_ds.RasterYSize
     dst_band = dst_ds.GetRasterBand(1)
     dst_nodata = dst_band.GetNoDataValue()
+    dst_srs_wkt = dst_ds.GetProjection()
+
+    f_type = filter_type(min(src_x_res, src_y_res))
+    res = gdal.ReprojectImage(src_ds, dst_ds, src_srs_wkt,
+                              dst_srs_wkt, f_type, 1024, 0.125)
+    assert res == gdal.CPLE_None
 
     if mask_negative:
         dst_data = dst_band.ReadAsArray(0, 0, dst_x_size, dst_y_size)
@@ -74,7 +63,7 @@ _NUMPY_TYPES = {
 #
 # dst_ds will be erased to its nodata value before composition starts.
 #
-def compose(layers, dst_ds, dst_bbox, logger, dst_res):
+def compose(tile, dst_ds, dst_bbox, logger, dst_res):
     dst_band = dst_ds.GetRasterBand(1)
     dst_nodata = dst_band.GetNoDataValue()
     dst_x_size = dst_ds.RasterXSize
@@ -101,8 +90,8 @@ def compose(layers, dst_ds, dst_bbox, logger, dst_res):
     # loop over layers in order, so the first layer will be overwritten
     # by any valid data values in later layers. so layers should be listed
     # in order of increasing detail.
-    for layer in layers:
-        logger.debug("Processing layer VRT: %r", layer.vrt_file())
+    for source in tile.sources:
+        logger.debug("Processing layer %s VRT", type(source).__name__)
 
         mem_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, dst_type)
         assert mem_ds is not None
@@ -114,11 +103,14 @@ def compose(layers, dst_ds, dst_bbox, logger, dst_res):
             numpy.full((dst_x_size, dst_y_size), dst_nodata, numpy_type))
 
         def _filter_type_func(src_res):
-            return layer.filter_type(src_res, dst_res)
+            return source.filter_type(src_res, dst_res)
 
-        vrt_file = layer.vrt_file()
-        _mk_image(layer.vrt_file(), mem_ds, dst_bbox, layer.mask_negative(),
-                  _filter_type_func)
+        # TODO!
+        rasters = source.downloads_for(tile)
+        with vrt.build([r.output_file() for r in rasters],
+                       source.srs().ExportToWkt()) as src_ds:
+            _mk_image(src_ds, mem_ds, source.mask_negative(),
+                      _filter_type_func)
 
         mem_band = mem_ds.GetRasterBand(1)
         mem_data = mem_band.ReadAsArray(0, 0, dst_x_size, dst_y_size)

--- a/joerd/config.py
+++ b/joerd/config.py
@@ -1,5 +1,6 @@
 from yaml import load
 from util import BoundingBox
+from multiprocessing import cpu_count
 
 
 class Configuration(object):
@@ -14,6 +15,8 @@ class Configuration(object):
         self.sources = self._cfg('sources')
         self.outputs = self._cfg('outputs')
         self.logconfig = self._cfg('logging config')
+        self.num_threads = self._cfg('jobs num_threads')
+        self.chunksize = self._cfg('jobs chunksize')
 
 
     def _cfg(self, yamlkeys_str):
@@ -31,6 +34,10 @@ def default_yml_config():
         'outputs': [],
         'logging': {
             'config': None
+        },
+        'jobs': {
+            'num_threads': cpu_count(),
+            'chunksize': None,
         },
     }
 

--- a/joerd/output/skadi.py
+++ b/joerd/output/skadi.py
@@ -16,6 +16,13 @@ import joerd.composite as composite
 HALF_ARC_SEC = (1.0/3600.0)*.5
 TILE_NAME_PATTERN = re.compile('^([NS])([0-9]{2})([EW])([0-9]{3})$')
 
+def _bbox(x, y):
+    return BoundingBox(
+        (x - 180) - HALF_ARC_SEC,
+        (y - 90) - HALF_ARC_SEC,
+        (x - 179) + HALF_ARC_SEC,
+        (y - 89) + HALF_ARC_SEC)
+
 
 def _tile_name(x, y):
     return '%s%02d%s%03d' % \
@@ -36,53 +43,30 @@ def _parse_tile(tile_name):
     return None
 
 
-class Skadi:
+class SkadiTile:
+    def __init__(self, parent, x, y):
+        self.parent = parent
+        self.x = x
+        self.y = y
+        self.sources = []
 
-    def __init__(self, regions, sources, options={}):
-        self.regions = regions
-        self.sources = sources
-        self.output_dir = options.get('output_dir', 'tiles')
+    def set_sources(self, sources):
+        self.source = sources
 
-    def _bbox(self, x, y):
-        return BoundingBox(
-            (x - 180) - HALF_ARC_SEC,
-            (y - 90) - HALF_ARC_SEC,
-            (x - 179) + HALF_ARC_SEC,
-            (y - 89) + HALF_ARC_SEC)
+    def latlon_bbox(self):
+        return _bbox(self.x, self.y)
 
-    def _intersects(self, bbox):
-        for r in self.regions:
-            if r.intersects(bbox):
-                return True
-        return False
+    def max_resolution(self):
+        return 1.0 / 3600;
 
-    def generate_tiles(self):
-        logger = logging.getLogger('skadi')
-        tiles = []
-
-        for x in range(0, 360):
-            for y in range(0, 180):
-                bbox = self._bbox(x, y)
-                if self._intersects(bbox):
-                    tiles.append(_tile_name(x, y))
-
-        logger.info("Generated %d tile jobs." % len(tiles))
-        return tiles
-
-    def process_tile(self, tile):
+    def render(self):
         logger = logging.getLogger('skadi')
 
-        t = _parse_tile(tile)
-        if t is None:
-            raise Exception("Unable to parse %r as skadi tile name."
-                            % tile)
+        bbox = _bbox(self.x, self.y)
 
-        logger.info("Generating tile %r..." % tile)
-        x, y = t
-        bbox = self._bbox(x, y)
-
-        mid_dir = os.path.join(self.output_dir,
-                               ("N" if y >= 90 else "S") + ("%02d" % abs(y-90)))
+        mid_dir = os.path.join(self.parent.output_dir,
+                               ("N" if self.y >= 90 else "S") +
+                               ("%02d" % abs(self.y - 90)))
         if not os.path.isdir(mid_dir):
             try:
                 os.makedirs(mid_dir)
@@ -92,7 +76,9 @@ class Skadi:
                 if e.errno != errno.EEXIST or not os.path.isdir(mid_dir):
                     raise
 
+        tile = _tile_name(self.x, self.y)
         tile_file = os.path.join(mid_dir, tile + ".hgt")
+        logger.info("Generating tile %r..." % tile_file)
 
         outfile = tile_file
         dst_bbox = bbox.bounds
@@ -114,7 +100,7 @@ class Skadi:
         dst_ds.SetProjection(dst_srs.ExportToWkt())
         dst_ds.GetRasterBand(1).SetNoDataValue(-32768)
 
-        composite.compose(self.sources, dst_ds, dst_bbox, logger,
+        composite.compose(self, dst_ds, dst_bbox, logger,
                           min(dst_x_res, dst_y_res))
 
         logger.info("Writing SRTMHGT: %r" % outfile)
@@ -127,6 +113,33 @@ class Skadi:
         assert os.path.isfile(tile_file)
 
         logger.info("Done generating tile %r" % tile_file)
+
+
+class Skadi:
+
+    def __init__(self, regions, sources, options={}):
+        self.regions = regions
+        self.sources = sources
+        self.output_dir = options.get('output_dir', 'tiles')
+
+    def _intersects(self, bbox):
+        for r in self.regions:
+            if r.intersects(bbox):
+                return True
+        return False
+
+    def generate_tiles(self):
+        logger = logging.getLogger('skadi')
+        tiles = []
+
+        for x in range(0, 360):
+            for y in range(0, 180):
+                bbox = _bbox(x, y)
+                if self._intersects(bbox):
+                    tiles.append(SkadiTile(self, x, y))
+
+        logger.info("Generated %d tile jobs." % len(tiles))
+        return tiles
 
 
 def create(regions, sources, options):

--- a/joerd/output/terrarium.py
+++ b/joerd/output/terrarium.py
@@ -89,6 +89,120 @@ def _lonlat_to_xy(zoom, lon, lat):
     return (tx, ty)
 
 
+class TerrariumTile:
+    def __init__(self, parent, z, x, y):
+        self.parent = parent
+        self.z = z
+        self.x = x
+        self.y = y
+
+    def set_sources(self, sources):
+        logger = logging.getLogger('terrarium')
+        logger.debug("Set sources on tile z=%r: %r"
+                     % (self.z, [type(s).__name__ for s in sources]))
+        self.sources = sources
+
+    def latlon_bbox(self):
+        return _latlon_bbox(self.z, self.x, self.y)
+
+    def max_resolution(self):
+        bbox = self.latlon_bbox().bounds
+        return max((bbox[2] - bbox[0]) / 256.0,
+                   (bbox[3] - bbox[1]) / 256.0)
+
+    def render(self):
+        logger = logging.getLogger('terrarium')
+
+        bbox = _merc_bbox(self.z, self.x, self.y)
+
+        mid_dir = os.path.join(self.parent.output_dir, str(self.z), str(self.x))
+        if not os.path.isdir(mid_dir):
+            try:
+                os.makedirs(mid_dir)
+            except OSError as e:
+                # swallow the error if the directory exists - it's
+                # probably another thread creating it.
+                if e.errno != errno.EEXIST or not os.path.isdir(mid_dir):
+                    raise
+
+        tile = _tile_name(self.z, self.x, self.y)
+        tile_file = os.path.join(self.parent.output_dir, tile + ".tif")
+        logger.debug("Generating tile %r..." % tile_file)
+
+        outfile = tile_file
+        dst_bbox = bbox.bounds
+        dst_x_size = 256
+        dst_y_size = 256
+
+        dst_srs = osr.SpatialReference()
+        dst_srs.ImportFromEPSG(3857)
+
+        dst_drv = gdal.GetDriverByName("GTiff")
+        dst_ds = dst_drv.Create(outfile, dst_x_size, dst_y_size, 1, gdal.GDT_Int16)
+        dst_x_res = float(dst_bbox[2] - dst_bbox[0]) / dst_x_size
+        dst_y_res = float(dst_bbox[3] - dst_bbox[1]) / dst_y_size
+        dst_gt = (dst_bbox[0], dst_x_res, 0,
+                  dst_bbox[3], 0, -dst_y_res)
+        dst_ds.SetGeoTransform(dst_gt)
+        dst_ds.SetProjection(dst_srs.ExportToWkt())
+        dst_ds.GetRasterBand(1).SetNoDataValue(-32768)
+
+        # figure out what the approximate scale of the output image is in
+        # lat/lon coordinates. this is used to select the appropriate filter.
+        ll_bbox = _latlon_bbox(self.z, self.x, self.y)
+        ll_x_res = float(ll_bbox.bounds[2] - ll_bbox.bounds[0]) / dst_x_size
+        ll_y_res = float(ll_bbox.bounds[3] - ll_bbox.bounds[1]) / dst_y_size
+
+        composite.compose(self, dst_ds, dst_bbox, logger,
+                          min(ll_x_res, ll_y_res))
+
+        mem_drv = gdal.GetDriverByName("MEM")
+        mem_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, gdal.GDT_UInt16)
+        mem_ds.SetGeoTransform(dst_gt)
+        mem_ds.SetProjection(dst_srs.ExportToWkt())
+        mem_ds.GetRasterBand(1).SetNoDataValue(0)
+
+        # convert from int16 to uint16 by shifting everything +32768. note that
+        # the conversion relies on uint16's wrap-around overflow behaviour.
+        # see this for more information:
+        # http://stackoverflow.com/questions/7715406/how-can-i-efficiently-transform-a-numpy-int8-array-in-place-to-a-value-shifted-n
+        pixels = dst_ds.GetRasterBand(1).ReadAsArray(0, 0, dst_x_size, dst_y_size)
+        pixels = pixels.view(numpy.uint16)
+        pixels += 32768
+        res = mem_ds.GetRasterBand(1).WriteArray(pixels)
+
+        png_file = os.path.join(self.parent.output_dir, tile + ".png")
+        png_drv = gdal.GetDriverByName("PNG")
+        png_ds = png_drv.CreateCopy(png_file, mem_ds)
+
+        # "browser" PNG is an image which will display okay in the browser. this
+        # can be very useful for demos, or checking that the data is looking
+        # okay. it's perhaps less useful for "production" use, so is disabled by
+        # default.
+        if self.parent.enable_browser_png:
+            pixels = (numpy.clip(pixels, 31768, 34317) - 31768) / 10
+            mem2_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, gdal.GDT_Byte)
+            mem2_ds.SetGeoTransform(dst_gt)
+            mem2_ds.SetProjection(dst_srs.ExportToWkt())
+            mem2_ds.GetRasterBand(1).SetNoDataValue(0)
+            mem2_ds.GetRasterBand(1).WriteArray(pixels)
+            png2_file = os.path.join(self.parent.output_dir, tile + ".u8.png")
+            png2_ds = png_drv.CreateCopy(png2_file, mem2_ds)
+
+            del mem2_ds
+            del png2_ds
+
+        del dst_ds
+        del mem_ds
+        del png_ds
+
+        assert os.path.isfile(tile_file)
+
+        source_names = [type(s).__name__ for s in self.sources]
+        logger.info("Done generating tile %r from %s"
+                    % (tile_file, ", ".join(source_names)))
+
+
 class Terrarium:
 
     def __init__(self, regions, sources, options={}):
@@ -115,105 +229,10 @@ class Terrarium:
 
                 for x in range(lx, ux + 1):
                     for y in range(ly, uy + 1):
-                        tiles.add(_tile_name(zoom, x, y))
+                        tiles.add(TerrariumTile(self, zoom, x, y))
 
         logger.info("Generated %d tile jobs." % len(tiles))
         return list(tiles)
-
-    def process_tile(self, tile):
-        logger = logging.getLogger('terrarium')
-
-        t = _parse_tile(tile)
-        if t is None:
-            raise Exception("Unable to parse %r as terrarium tile name."
-                            % tile)
-
-        logger.debug("Generating tile %r..." % tile)
-        z, x, y = t
-        bbox = _merc_bbox(z, x, y)
-
-        mid_dir = os.path.join(self.output_dir, str(z), str(x))
-        if not os.path.isdir(mid_dir):
-            try:
-                os.makedirs(mid_dir)
-            except OSError as e:
-                # swallow the error if the directory exists - it's
-                # probably another thread creating it.
-                if e.errno != errno.EEXIST or not os.path.isdir(mid_dir):
-                    raise
-
-        tile_file = os.path.join(self.output_dir, tile + ".tif")
-
-        outfile = tile_file
-        dst_bbox = bbox.bounds
-        dst_x_size = 256
-        dst_y_size = 256
-
-        dst_srs = osr.SpatialReference()
-        dst_srs.ImportFromEPSG(3857)
-
-        dst_drv = gdal.GetDriverByName("GTiff")
-        dst_ds = dst_drv.Create(outfile, dst_x_size, dst_y_size, 1, gdal.GDT_Int16)
-        dst_x_res = float(dst_bbox[2] - dst_bbox[0]) / dst_x_size
-        dst_y_res = float(dst_bbox[3] - dst_bbox[1]) / dst_y_size
-        dst_gt = (dst_bbox[0], dst_x_res, 0,
-                  dst_bbox[3], 0, -dst_y_res)
-        dst_ds.SetGeoTransform(dst_gt)
-        dst_ds.SetProjection(dst_srs.ExportToWkt())
-        dst_ds.GetRasterBand(1).SetNoDataValue(-32768)
-
-        # figure out what the approximate scale of the output image is in
-        # lat/lon coordinates. this is used to select the appropriate filter.
-        ll_bbox = _latlon_bbox(z, x, y)
-        ll_x_res = float(ll_bbox.bounds[2] - ll_bbox.bounds[0]) / dst_x_size
-        ll_y_res = float(ll_bbox.bounds[3] - ll_bbox.bounds[1]) / dst_y_size
-
-        composite.compose(self.sources, dst_ds, dst_bbox, logger,
-                          min(ll_x_res, ll_y_res))
-
-        mem_drv = gdal.GetDriverByName("MEM")
-        mem_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, gdal.GDT_UInt16)
-        mem_ds.SetGeoTransform(dst_gt)
-        mem_ds.SetProjection(dst_srs.ExportToWkt())
-        mem_ds.GetRasterBand(1).SetNoDataValue(0)
-
-        # convert from int16 to uint16 by shifting everything +32768. note that
-        # the conversion relies on uint16's wrap-around overflow behaviour.
-        # see this for more information:
-        # http://stackoverflow.com/questions/7715406/how-can-i-efficiently-transform-a-numpy-int8-array-in-place-to-a-value-shifted-n
-        pixels = dst_ds.GetRasterBand(1).ReadAsArray(0, 0, dst_x_size, dst_y_size)
-        pixels = pixels.view(numpy.uint16)
-        pixels += 32768
-        res = mem_ds.GetRasterBand(1).WriteArray(pixels)
-
-        png_file = os.path.join(self.output_dir, tile + ".png")
-        png_drv = gdal.GetDriverByName("PNG")
-        png_ds = png_drv.CreateCopy(png_file, mem_ds)
-
-        # "browser" PNG is an image which will display okay in the browser. this
-        # can be very useful for demos, or checking that the data is looking
-        # okay. it's perhaps less useful for "production" use, so is disabled by
-        # default.
-        if self.enable_browser_png:
-            pixels = (numpy.clip(pixels, 31768, 34317) - 31768) / 10
-            mem2_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, gdal.GDT_Byte)
-            mem2_ds.SetGeoTransform(dst_gt)
-            mem2_ds.SetProjection(dst_srs.ExportToWkt())
-            mem2_ds.GetRasterBand(1).SetNoDataValue(0)
-            mem2_ds.GetRasterBand(1).WriteArray(pixels)
-            png2_file = os.path.join(self.output_dir, tile + ".u8.png")
-            png2_ds = png_drv.CreateCopy(png2_file, mem2_ds)
-
-            del mem2_ds
-            del png2_ds
-
-        del dst_ds
-        del mem_ds
-        del png_ds
-
-        assert os.path.isfile(tile_file)
-
-        logger.info("Done generating tile %r" % tile_file)
 
 
 def create(regions, sources, options):

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -1,6 +1,7 @@
 from joerd.util import BoundingBox
 import joerd.download as download
 import joerd.check as check
+import joerd.srs as srs
 from contextlib import closing
 from shutil import copyfile
 import os.path
@@ -17,63 +18,43 @@ import glob
 from osgeo import gdal
 
 
-WGS84_WKT = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,' \
-            '298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0]' \
-            ',AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY[' \
-            '"EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY[' \
-            '"EPSG","9108"]],AUTHORITY["EPSG","4326"]]'
-
-
-def _download_etopo1_file(target_name, base_dir, url, options):
-    output_file = os.path.join(base_dir, target_name)
-
-    if os.path.isfile(output_file):
-        return output_file
-
-    options['verifier'] = check.is_zip
-    with download.get(url, options) as tmp:
-        with zipfile.ZipFile(tmp.name, 'r') as zfile:
-            zfile.extract(target_name, base_dir)
-
-    return output_file
-
-
-class ETOPO1:
+class ETOPO1(object):
 
     def __init__(self, options={}):
         self.base_dir = options.get('base_dir', 'etopo1')
         self.etopo1_url = options['url']
         self.download_options = download.options(options)
+        self.target_name = 'ETOPO1_Bed_g_geotiff.tif'
 
-    def download(self):
-        logger = logging.getLogger('etopo1')
-        logger.info("Starting ETOPO1 download, this may take some time...")
-        file = _download_etopo1_file('ETOPO1_Bed_g_geotiff.tif',
-                                     self.base_dir, self.etopo1_url,
-                                     self.download_options)
-        assert os.path.isfile(file)
-        logger.info("Download complete.")
+    def get_index(self):
+        # ETOPO1 needs no index - it's a single file, for which we'll need
+        # a directory to call home.
+        if not os.path.isdir(self.base_dir):
+            os.makedirs(self.base_dir)
 
-    def buildvrt(self):
-        logger = logging.getLogger('etopo1')
-        logger.info("Creating VRT.")
+    def downloads_for(self, tile):
+        # There's just one thing to download, and it's this single world
+        # tile.
+        return set([self])
 
-        # ETOPO1 covers the whole world
-        files = glob.glob(os.path.join(self.base_dir, '*.tif'))
+    def output_file(self):
+        return os.path.join(self.base_dir, self.target_name)
 
-        args = ["gdalbuildvrt", "-q", "-a_srs", WGS84_WKT, \
-                self.vrt_file()] + files
-        status = subprocess.call(args)
+    def url(self):
+        return self.etopo1_url
 
-        if status != 0:
-            raise Exception("Call to gdalbuildvrt failed: status=%r" % status)
+    def options(self):
+        return self.download_options
 
-        assert os.path.isfile(self.vrt_file())
+    def verifier(self):
+        return check.is_zip
 
-        logger.info("VRT created.")
+    def unpack(self, tmp):
+        with zipfile.ZipFile(tmp.name, 'r') as zfile:
+            zfile.extract(self.target_name, self.base_dir)
 
-    def vrt_file(self):
-        return os.path.join(self.base_dir, "etopo1.vrt")
+    def srs(self):
+        return srs.wgs84()
 
     def mask_negative(self):
         return False

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -63,5 +63,5 @@ class ETOPO1(object):
         return gdal.GRA_Lanczos
 
 
-def create(regions, options):
+def create(options):
     return ETOPO1(options)

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -67,8 +67,7 @@ class GMTEDTile(object):
 
 class GMTED(object):
 
-    def __init__(self, regions, options={}):
-        self.regions = regions
+    def __init__(self, options={}):
         self.num_download_threads = options.get('num_download_threads')
         self.base_dir = options.get('base_dir', 'gmted')
         self.url = options['url']
@@ -124,5 +123,5 @@ class GMTED(object):
         return b
 
 
-def create(regions, options):
-    return GMTED(regions, options)
+def create(options):
+    return GMTED(options)

--- a/joerd/source/ned.py
+++ b/joerd/source/ned.py
@@ -11,11 +11,11 @@ NORMAL_PATTERN = re.compile('^ned19_' \
 
 
 class NED(object):
-    def __init__(self, regions, options={}):
+    def __init__(self, options={}):
         options = options.copy()
         options['pattern'] = NORMAL_PATTERN
         options['base_dir'] = options.get('base_dir', 'ned')
-        self.base = NEDBase(regions, options)
+        self.base = NEDBase(options)
 
     def get_index(self):
         return self.base.get_index()
@@ -33,5 +33,5 @@ class NED(object):
         return self.base.srs()
 
 
-def create(regions, options):
-    return NED(regions, options)
+def create(options):
+    return NED(options)

--- a/joerd/source/ned.py
+++ b/joerd/source/ned.py
@@ -2,34 +2,35 @@ from ned_base import NEDBase
 import re
 import os.path
 
+
 NORMAL_PATTERN = re.compile('^ned19_' \
                             '([ns])([0-9]{2})x([0257][05])_' \
                             '([ew])([0-9]{3})x([0257][05])_' \
-                            '[a-z]{2}_[a-z]+_20[0-9]{2}.(zip|img)$')
+                            '[a-z]{2}(_(?!topobathy)[a-z0-9]+)+' \
+                            '_20[0-9]{2}.(zip|img)$')
 
 
 class NED(object):
     def __init__(self, regions, options={}):
         options = options.copy()
-        options.update(dict(
-            pattern=NORMAL_PATTERN,
-            vrt_file="ned.vrt"))
+        options['pattern'] = NORMAL_PATTERN
+        options['base_dir'] = options.get('base_dir', 'ned')
         self.base = NEDBase(regions, options)
 
-    def download(self):
-        self.base.download()
+    def get_index(self):
+        return self.base.get_index()
 
-    def buildvrt(self):
-        self.base.buildvrt()
+    def downloads_for(self, tile):
+        return self.base.downloads_for(tile)
 
     def filter_type(self, src_res, dst_res):
         return self.base.filter_type(src_res, dst_res)
 
-    def vrt_file(self):
-        return self.base.vrt_file()
-
     def mask_negative(self):
         return True
+
+    def srs(self):
+        return self.base.srs()
 
 
 def create(regions, options):

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -66,8 +66,7 @@ class NEDTile(object):
 
 class NEDBase(object):
 
-    def __init__(self, regions, options={}):
-        self.regions = regions
+    def __init__(self, options={}):
         self.num_download_threads = options.get('num_download_threads')
         self.base_dir = options['base_dir']
         self.ftp_server = options['ftp_server']

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -1,6 +1,7 @@
 from joerd.util import BoundingBox
 import joerd.download as download
 import joerd.check as check
+import joerd.srs as srs
 from multiprocessing import Pool
 from contextlib import closing
 from shutil import copyfile
@@ -19,52 +20,48 @@ import glob
 from osgeo import gdal
 import urllib2
 import shutil
+import yaml
+import time
 
 
-def __download_ned_file(img_name, zip_name, base_dir, ftp_server, base_path,
-                        options):
-    logger = logging.getLogger('ned')
-    output_file = os.path.join(base_dir, img_name)
+GLOBAL_CACHE = {}
 
-    if os.path.isfile(output_file):
-        return output_file
 
-    url = 'ftp://%s/%s/%s' % (ftp_server, base_path, zip_name)
+class NEDTile(object):
+    def __init__(self, parent, fname, zname, bbox):
+        self.parent = parent
+        self.img_name = fname
+        self.zip_name = zname
+        self.bbox = bbox
 
-    options['verifier'] = check.is_zip
-    with download.get(url, options) as tmp:
+    def __key(self):
+        return (self.img_name, self.zip_name, self.bbox)
+
+    def __eq__(a, b):
+        return isinstance(b, type(a)) and \
+            a.__key() == b.__key()
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def url(self):
+        return 'ftp://%s/%s/%s' % (self.parent.ftp_server,
+                                   self.parent.base_path,
+                                   self.zip_name)
+
+    def verifier(self):
+        return check.is_zip
+
+    def options(self):
+        return self.parent.download_options
+
+    def output_file(self):
+        return os.path.join(self.parent.base_dir, self.img_name)
+
+    def unpack(self, tmp):
         with zipfile.ZipFile(tmp.name, 'r') as zfile:
-            zfile.extract(img_name, base_dir)
-            zfile.extract(img_name + ".aux.xml", base_dir)
-
-    return output_file
-
-
-def _download_ned_file(img_name, zip_name, base_dir, ftp_server, base_path,
-                       options):
-    try:
-        return __download_ned_file(img_name, zip_name, base_dir, ftp_server,
-                                   base_path, options)
-    except:
-        print>>sys.stderr, "Caught exception: %s" % \
-            ("\n".join(traceback.format_exception(*sys.exc_info())))
-        raise
-
-
-def _parallel(func, iterable, num_threads=None):
-    p = Pool(processes=num_threads)
-    threads = []
-
-    for x in iterable:
-        p.apply_async(func, x)
-
-    p.close()
-    return_values = []
-    for t in threads:
-        return_values.append(t.get())
-
-    p.join()
-    return return_values
+            zfile.extract(self.img_name, self.parent.base_dir)
+            zfile.extract(self.img_name + ".aux.xml", self.parent.base_dir)
 
 
 class NEDBase(object):
@@ -72,69 +69,59 @@ class NEDBase(object):
     def __init__(self, regions, options={}):
         self.regions = regions
         self.num_download_threads = options.get('num_download_threads')
-        self.base_dir = options.get('base_dir', 'ned')
+        self.base_dir = options['base_dir']
         self.ftp_server = options['ftp_server']
         self.base_path = options['base_path']
         self.pattern = re.compile(options['pattern'])
-        self.vrt_filename = options['vrt_file']
         self.download_options = download.options(options)
 
-    def download(self):
+    def get_index(self):
+        index_file = os.path.join(self.base_dir, 'index.yaml')
+        # if index doesn't exist, or is more than 24h old
+        if not os.path.isfile(index_file) or \
+           time.time() > os.path.getmtime(index_file) + 86400:
+            self.download_index(index_file)
+
+    def download_index(self, index_file):
+        if not os.path.isdir(self.base_dir):
+            os.makedirs(self.base_dir)
+
         logger = logging.getLogger('ned')
         logger.info('Fetching NED index...')
 
         files = []
         for bbox, fname, zname in self._list_ned_files():
-            if self._intersects(bbox):
-                files.append((fname, zname))
+            files.append(dict(fname=fname, zname=zname, bbox=bbox.bounds))
 
-        if not os.path.isdir(self.base_dir):
-            os.makedirs(self.base_dir)
+        with open(index_file, 'w') as f:
+            f.write(yaml.dump(files))
 
-        logger.info("Starting download of %d NED files." % len(files))
-        files = _parallel(
-            _download_ned_file,
-            [(f, z, self.base_dir, self.ftp_server, self.base_path,
-              self.download_options) for f, z in files],
-            num_threads=self.num_download_threads)
+    def downloads_for(self, tile):
+        tiles = set()
+        # if the tile scale is greater than 20x the NED scale, then there's no
+        # point in including NED, it'll be far too fine to make a difference.
+        # NED is 1/9th arc second.
+        if tile.max_resolution() > 20 * 1.0 / (3600 * 9):
+            return tiles
 
-        # sanity check
-        for f, z in files:
-            assert os.path.isfile(os.path.join(self.base_dir, f))
+        # buffer by 0.0025 degrees (81px) to grab neighbouring tiles and ensure
+        # some overlap to take care of boundary issues.
+        tile_bbox = tile.latlon_bbox().buffer(0.0025)
 
-        logger.info("Download complete.")
+        files = GLOBAL_CACHE.get('index')
+        if files is None:
+            index_file = os.path.join(self.base_dir, 'index.yaml')
+            with open(index_file, 'r') as f:
+                files = yaml.load(f.read())
+            GLOBAL_CACHE['index'] = files
 
-    def buildvrt(self):
-        logger = logging.getLogger('ned')
-        logger.info("Creating VRT.")
+        for f in files:
+            bbox = BoundingBox(*f['bbox'])
+            if tile_bbox.intersects(bbox) and \
+               self.pattern.match(f['fname']):
+                tiles.add(NEDTile(self, f['fname'], f['zname'], bbox))
 
-        files = []
-        for f in glob.glob(os.path.join(self.base_dir, '*.img')):
-            bbox = self._ned_parse_filename(os.path.split(f)[1])
-            if bbox and self._intersects(bbox):
-                files.append(f)
-
-        args = ["gdalbuildvrt", "-q", self.vrt_file()] + files
-        status = subprocess.call(args)
-
-        if status != 0:
-            raise Exception("Call to gdalbuildvrt failed: status=%r" % status)
-
-        assert os.path.isfile(self.vrt_file())
-
-        logger.info("VRT created.")
-
-    def filter_type(self, src_res, dst_res):
-        return gdal.GRA_Lanczos if src_res > dst_res else gdal.GRA_Cubic
-
-    def vrt_file(self):
-        return os.path.join(self.base_dir, self.vrt_filename)
-
-    def _intersects(self, bbox):
-        for r in self.regions:
-            if r.intersects(bbox):
-                return True
-        return False
+        return tiles
 
     def _list_ned_files(self):
         ftp = FTP(self.ftp_server)
@@ -157,6 +144,11 @@ class NEDBase(object):
 
         return files
 
+    def filter_type(self, src_res, dst_res):
+        return gdal.GRA_Lanczos if src_res > dst_res else gdal.GRA_Cubic
+
+    def srs(self):
+        return srs.wgs84()
 
     def _ned_parse_filename(self, fname):
         m = self.pattern.match(fname)

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -24,9 +24,6 @@ import yaml
 import time
 
 
-GLOBAL_CACHE = {}
-
-
 class NEDTile(object):
     def __init__(self, parent, fname, zname, bbox):
         self.parent = parent
@@ -73,6 +70,7 @@ class NEDBase(object):
         self.base_path = options['base_path']
         self.pattern = re.compile(options['pattern'])
         self.download_options = download.options(options)
+        self.index_cache = None
 
     def get_index(self):
         index_file = os.path.join(self.base_dir, 'index.yaml')
@@ -107,12 +105,12 @@ class NEDBase(object):
         # some overlap to take care of boundary issues.
         tile_bbox = tile.latlon_bbox().buffer(0.0025)
 
-        files = GLOBAL_CACHE.get('index')
+        files = self.index_cache
         if files is None:
             index_file = os.path.join(self.base_dir, 'index.yaml')
             with open(index_file, 'r') as f:
                 files = yaml.load(f.read())
-            GLOBAL_CACHE['index'] = files
+            self.index_cache = files
 
         for f in files:
             bbox = BoundingBox(*f['bbox'])

--- a/joerd/source/ned_topobathy.py
+++ b/joerd/source/ned_topobathy.py
@@ -12,25 +12,25 @@ TOPOBATHY_PATTERN = re.compile('^ned19_' \
 
 class NEDTopobathy(object):
     def __init__(self, regions, options={}):
-        options.update(dict(
-            pattern=TOPOBATHY_PATTERN,
-            vrt_file="ned_topobathy.vrt"))
+        options = options.copy()
+        options['pattern'] = TOPOBATHY_PATTERN
+        options['base_dir'] = options.get('base_dir', 'ned_topobathy')
         self.base = NEDBase(regions, options)
 
-    def download(self):
-        self.base.download()
+    def get_index(self):
+        return self.base.get_index()
 
-    def buildvrt(self):
-        self.base.buildvrt()
+    def downloads_for(self, tile):
+        return self.base.downloads_for(tile)
 
     def filter_type(self, src_res, dst_res):
         return self.base.filter_type(src_res, dst_res)
 
-    def vrt_file(self):
-        return self.base.vrt_file()
-
     def mask_negative(self):
         return False
+
+    def srs(self):
+        return self.base.srs()
 
 
 def create(regions, options):

--- a/joerd/source/ned_topobathy.py
+++ b/joerd/source/ned_topobathy.py
@@ -11,11 +11,11 @@ TOPOBATHY_PATTERN = re.compile('^ned19_' \
 
 
 class NEDTopobathy(object):
-    def __init__(self, regions, options={}):
+    def __init__(self, options={}):
         options = options.copy()
         options['pattern'] = TOPOBATHY_PATTERN
         options['base_dir'] = options.get('base_dir', 'ned_topobathy')
-        self.base = NEDBase(regions, options)
+        self.base = NEDBase(options)
 
     def get_index(self):
         return self.base.get_index()
@@ -33,5 +33,5 @@ class NEDTopobathy(object):
         return self.base.srs()
 
 
-def create(regions, options):
-    return NEDTopobathy(regions, options)
+def create(options):
+    return NEDTopobathy(options)

--- a/joerd/source/srtm.py
+++ b/joerd/source/srtm.py
@@ -64,8 +64,7 @@ class SRTMTile(object):
 
 class SRTM(object):
 
-    def __init__(self, regions, options={}):
-        self.regions = regions
+    def __init__(self, options={}):
         self.base_dir = options.get('base_dir', 'srtm')
         self.url = options['url']
         self.download_options = download.options(options)
@@ -150,5 +149,5 @@ class SRTM(object):
         return BoundingBox(left, bottom, left + 1, bottom + 1)
 
 
-def create(regions, options):
-    return SRTM(regions, options)
+def create(options):
+    return SRTM(options)

--- a/joerd/source/srtm.py
+++ b/joerd/source/srtm.py
@@ -21,9 +21,6 @@ import yaml
 import time
 
 
-GLOBAL_CACHE = {}
-
-
 IS_SRTM_FILE = re.compile(
     '^([NS])([0-9]{2})([EW])([0-9]{3}).SRTMGL1.hgt.zip$')
 
@@ -68,6 +65,7 @@ class SRTM(object):
         self.base_dir = options.get('base_dir', 'srtm')
         self.url = options['url']
         self.download_options = download.options(options)
+        self.index_cache = None
 
     def get_index(self):
         index_file = os.path.join(self.base_dir, 'index.yaml')
@@ -109,12 +107,12 @@ class SRTM(object):
         # that there aren't any boundary artefacts.
         tile_bbox = tile.latlon_bbox().buffer(0.01)
 
-        links = GLOBAL_CACHE.get('index')
+        links = self.index_cache
         if links is None:
             index_file = os.path.join(self.base_dir, 'index.yaml')
             with open(index_file, 'r') as f:
                 links = yaml.load(f.read())
-            GLOBAL_CACHE['index'] = links
+            self.index_cache = links
 
         for link in links:
             bbox = BoundingBox(*link['bbox'])

--- a/joerd/srs.py
+++ b/joerd/srs.py
@@ -1,0 +1,13 @@
+from osgeo import osr
+
+WGS84_WKT = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,' \
+            '298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0]' \
+            ',AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY[' \
+            '"EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY[' \
+            '"EPSG","9108"]],AUTHORITY["EPSG","4326"]]'
+
+
+def wgs84():
+    sr = osr.SpatialReference()
+    sr.ImportFromWkt(WGS84_WKT)
+    return sr

--- a/joerd/util.py
+++ b/joerd/util.py
@@ -2,6 +2,13 @@ class BoundingBox:
     def __init__(self, left, bottom, right, top):
         self.bounds = (left, bottom, right, top)
 
+    def __eq__(a, b):
+        return isinstance(b, type(a)) and \
+            a.bounds == b.bounds
+
+    def __hash__(self):
+        return hash(self.bounds)
+
     def intersects(self, other):
         if self.bounds[0] > other.bounds[2]:
             return False
@@ -12,3 +19,10 @@ class BoundingBox:
         if self.bounds[3] < other.bounds[1]:
             return False
         return True
+
+    def buffer(self, size):
+        return BoundingBox(
+            self.bounds[0] - size,
+            self.bounds[1] - size,
+            self.bounds[2] + size,
+            self.bounds[3] + size)

--- a/joerd/vrt.py
+++ b/joerd/vrt.py
@@ -1,0 +1,19 @@
+from osgeo import gdal
+from contextlib import contextmanager, closing
+import subprocess
+import tempfile
+import logging
+
+
+@contextmanager
+def build(files, srs):
+    with closing(tempfile.NamedTemporaryFile(suffix='.vrt')) as vrt:
+        args = ["gdalbuildvrt", "-q", "-a_srs", srs, vrt.name ] + files
+        status = subprocess.call(args)
+
+        if status != 0:
+            raise Exception("Call to gdalbuildvrt failed: status=%r" % status)
+
+        ds = gdal.Open(vrt.name)
+        yield ds
+        del ds

--- a/logging.example.config
+++ b/logging.example.config
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,srtm,skadi,gmted,etopo1,terrarium,ned,download
+keys=root,srtm,skadi,gmted,etopo1,terrarium,ned,download,process
 
 [handlers]
 keys=consoleHandler
@@ -50,6 +50,12 @@ propagate=0
 [logger_download]
 level=INFO
 qualname=download
+handlers=consoleHandler
+propagate=0
+
+[logger_process]
+level=INFO
+qualname=process
 handlers=consoleHandler
 propagate=0
 

--- a/tests/test_ned.py
+++ b/tests/test_ned.py
@@ -31,6 +31,12 @@ class TestNEDSource(unittest.TestCase):
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is None)
 
+    def test_zip_file_name_parsing_normal_topo_2(self):
+        fname = 'ned19_n38x00_w122x50_tx_cameronco06_cameronco_2003.zip'
+        n = ned_topo.create([], FAKE_OPTIONS)
+        bbox = n.base._ned_parse_filename(fname)
+        self.assertTrue(bbox is None)
+
     def test_zip_file_name_parsing_normal(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_2010.zip'
         n = ned.create([], FAKE_OPTIONS)
@@ -40,6 +46,13 @@ class TestNEDSource(unittest.TestCase):
 
     def test_img_file_name_parsing_normal(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_2010.img'
+        n = ned.create([], FAKE_OPTIONS)
+        bbox = n.base._ned_parse_filename(fname)
+        self.assertTrue(bbox is not None)
+        self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
+
+    def test_zip_file_name_parsing_normal_2(self):
+        fname = 'ned19_n38x00_w122x50_tx_cameronco06_cameronco_2003.zip'
         n = ned.create([], FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is not None)

--- a/tests/test_ned.py
+++ b/tests/test_ned.py
@@ -13,53 +13,53 @@ class TestNEDSource(unittest.TestCase):
 
     def test_zip_file_name_parsing_topo(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_topobathy_2010.zip'
-        n = ned_topo.create([], FAKE_OPTIONS)
+        n = ned_topo.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is not None)
         self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
 
     def test_img_file_name_parsing_topo(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_topobathy_2010.img'
-        n = ned_topo.create([], FAKE_OPTIONS)
+        n = ned_topo.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is not None)
         self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
 
     def test_none_file_name_parsing_topo(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_2010.img'
-        n = ned_topo.create([], FAKE_OPTIONS)
+        n = ned_topo.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is None)
 
     def test_zip_file_name_parsing_normal_topo_2(self):
         fname = 'ned19_n38x00_w122x50_tx_cameronco06_cameronco_2003.zip'
-        n = ned_topo.create([], FAKE_OPTIONS)
+        n = ned_topo.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is None)
 
     def test_zip_file_name_parsing_normal(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_2010.zip'
-        n = ned.create([], FAKE_OPTIONS)
+        n = ned.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is not None)
         self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
 
     def test_img_file_name_parsing_normal(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_2010.img'
-        n = ned.create([], FAKE_OPTIONS)
+        n = ned.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is not None)
         self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
 
     def test_zip_file_name_parsing_normal_2(self):
         fname = 'ned19_n38x00_w122x50_tx_cameronco06_cameronco_2003.zip'
-        n = ned.create([], FAKE_OPTIONS)
+        n = ned.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is not None)
         self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
 
     def test_none_file_name_parsing_normal(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_topobathy_2010.img'
-        n = ned.create([], FAKE_OPTIONS)
+        n = ned.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is None)

--- a/tests/test_srtm.py
+++ b/tests/test_srtm.py
@@ -1,0 +1,24 @@
+import unittest
+import joerd.source.srtm as srtm
+
+
+FAKE_OPTIONS = dict(
+    url='',
+)
+
+
+class TestSRTMSource(unittest.TestCase):
+
+    def test_file_name_parsing_1(self):
+        fname = 'N37W123.SRTMGL1.hgt.zip'
+        s = srtm.create([], FAKE_OPTIONS)
+        bbox = s._parse_bbox(fname)
+        self.assertTrue(bbox is not None)
+        self.assertEqual((-123, 37, -122, 38), bbox.bounds)
+
+    def test_file_name_parsing_2(self):
+        fname = 'N38W122.SRTMGL1.hgt.zip'
+        s = srtm.create([], FAKE_OPTIONS)
+        bbox = s._parse_bbox(fname)
+        self.assertTrue(bbox is not None)
+        self.assertEqual((-122, 38, -121, 39), bbox.bounds)

--- a/tests/test_srtm.py
+++ b/tests/test_srtm.py
@@ -11,14 +11,14 @@ class TestSRTMSource(unittest.TestCase):
 
     def test_file_name_parsing_1(self):
         fname = 'N37W123.SRTMGL1.hgt.zip'
-        s = srtm.create([], FAKE_OPTIONS)
+        s = srtm.create(FAKE_OPTIONS)
         bbox = s._parse_bbox(fname)
         self.assertTrue(bbox is not None)
         self.assertEqual((-123, 37, -122, 38), bbox.bounds)
 
     def test_file_name_parsing_2(self):
         fname = 'N38W122.SRTMGL1.hgt.zip'
-        s = srtm.create([], FAKE_OPTIONS)
+        s = srtm.create(FAKE_OPTIONS)
         bbox = s._parse_bbox(fname)
         self.assertTrue(bbox is not None)
         self.assertEqual((-122, 38, -121, 39), bbox.bounds)


### PR DESCRIPTION
A lot of the code for downloading and processing tiles was duplicated in each source. This has now been factored out into the command process. The downloads are now all run through a single queue, which allows them to all be run in parallel, which helps when a small number of requests (e.g: GMTED) take a
disproportionate amount of time to download (and retry, retry, retry...)

Note that this means the `download`, `buildvrt`, `generate` steps are all merged into one, in preparation for #11.

Also the source bounding boxes are now based on the padded extents of the requested regions (fixes #16), and data sources now cache their indexes (fixes #13).

Connects to #19.

@rmarianski could you review, please?