### PR TITLE
Fix overlapping NED

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,10 +27,9 @@ sources:
     tries: 100
   - type: srtm
     url: http://e4ftl01.cr.usgs.gov/SRTM/SRTMGL1.003/2000.02.11/
-  # disable, until https://github.com/mapzen/joerd/issues/3 is sorted out
-  # - type: ned
-  #   ftp_server: rockyftp.cr.usgs.gov
-  #   base_path: vdelivery/Datasets/Staged/NED/19/IMG
+  - type: ned
+    ftp_server: rockyftp.cr.usgs.gov
+    base_path: vdelivery/Datasets/Staged/NED/19/IMG
   - type: ned_topobathy
     ftp_server: rockyftp.cr.usgs.gov
     base_path: vdelivery/Datasets/Staged/NED/19/IMG

--- a/joerd/index.py
+++ b/joerd/index.py
@@ -1,0 +1,30 @@
+import pyqtree
+import yaml
+import logging
+import thread
+
+
+# Create an index given a YAML file consisting of a list of strings and a
+# function to parse it. Extra, fixed arguments for the function can be also
+# be given. Each object returned from the `parse_fn` should have a member
+# called `bbox` which is a `joerd.util.BoundingBox` instance.
+def create(index_file, bbox, parse_fn, *parse_args):
+    logger = logging.getLogger("index")
+    idx = pyqtree.Index(bbox=bbox)
+    n = 0
+
+    with open(index_file, 'r') as f:
+        files = yaml.load(f.read())
+        for f in files:
+            t = parse_fn(f, *parse_args)
+            if t:
+                idx.insert(bbox=t.bbox.bounds, item=t)
+                n += 1
+
+    logger.info("Created index with %d objects." % n)
+    return idx
+
+
+# Returns a list of all objects intersecting the given bbox in the index.
+def intersections(idx, bbox):
+    return idx.intersect(bbox.bounds)

--- a/joerd/index.py
+++ b/joerd/index.py
@@ -14,7 +14,7 @@ def create(index_file, bbox, parse_fn, *parse_args):
     n = 0
 
     with open(index_file, 'r') as f:
-        files = yaml.load(f.read())
+        files = yaml.load(f)
         for f in files:
             t = parse_fn(f, *parse_args)
             if t:

--- a/joerd/output/skadi.py
+++ b/joerd/output/skadi.py
@@ -100,8 +100,7 @@ class SkadiTile:
         dst_ds.SetProjection(dst_srs.ExportToWkt())
         dst_ds.GetRasterBand(1).SetNoDataValue(-32768)
 
-        composite.compose(self, dst_ds, dst_bbox, logger,
-                          min(dst_x_res, dst_y_res))
+        composite.compose(self, dst_ds, logger, min(dst_x_res, dst_y_res))
 
         logger.info("Writing SRTMHGT: %r" % outfile)
         srtm_drv = gdal.GetDriverByName("SRTMHGT")

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -37,6 +37,19 @@ class ETOPO1(object):
         # tile.
         return set([self])
 
+    def vrts_for(self, tile):
+        """
+        Returns a list of sets of tiles, with each list element intended as a
+        separate VRT for use in GDAL.
+
+        The reason for this is that GDAL doesn't do any compositing _within_
+        a single VRT, so if there are multiple overlapping source rasters in
+        the VRT, only one will be chosen. This isn't often the case - most
+        raster datasets are non-overlapping apart from deliberately duplicated
+        margins.
+        """
+        return [self.downloads_for(tile)]
+
     def output_file(self):
         return os.path.join(self.base_dir, self.target_name)
 

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -101,6 +101,19 @@ class GMTED(object):
 
         return tiles
 
+    def vrts_for(self, tile):
+        """
+        Returns a list of sets of tiles, with each list element intended as a
+        separate VRT for use in GDAL.
+
+        The reason for this is that GDAL doesn't do any compositing _within_
+        a single VRT, so if there are multiple overlapping source rasters in
+        the VRT, only one will be chosen. This isn't often the case - most
+        raster datasets are non-overlapping apart from deliberately duplicated
+        margins.
+        """
+        return [self.downloads_for(tile)]
+
     def srs(self):
         return srs.wgs84()
 

--- a/joerd/source/ned.py
+++ b/joerd/source/ned.py
@@ -23,6 +23,9 @@ class NED(object):
     def downloads_for(self, tile):
         return self.base.downloads_for(tile)
 
+    def vrts_for(self, tile):
+        return self.base.vrts_for(tile)
+
     def filter_type(self, src_res, dst_res):
         return self.base.filter_type(src_res, dst_res)
 

--- a/joerd/source/ned_topobathy.py
+++ b/joerd/source/ned_topobathy.py
@@ -23,6 +23,9 @@ class NEDTopobathy(object):
     def downloads_for(self, tile):
         return self.base.downloads_for(tile)
 
+    def vrts_for(self, tile):
+        return self.base.vrts_for(tile)
+
     def filter_type(self, src_res, dst_res):
         return self.base.filter_type(src_res, dst_res)
 

--- a/logging.example.config
+++ b/logging.example.config
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,srtm,skadi,gmted,etopo1,terrarium,ned,download,process
+keys=root,srtm,skadi,gmted,etopo1,terrarium,ned,download,process,index
 
 [handlers]
 keys=consoleHandler
@@ -56,6 +56,12 @@ propagate=0
 [logger_process]
 level=INFO
 qualname=process
+handlers=consoleHandler
+propagate=0
+
+[logger_index]
+level=INFO
+qualname=index
 handlers=consoleHandler
 propagate=0
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name='joerd',
           'requests',
           'numpy',
           'PyYAML',
+          'pyqtree',
       ],
       test_suite='tests',
       tests_require=[

--- a/tests/test_ned.py
+++ b/tests/test_ned.py
@@ -1,5 +1,6 @@
 import unittest
 import joerd.source.ned as ned
+import joerd.source.ned_base as ned_base
 import joerd.source.ned_topobathy as ned_topo
 
 
@@ -18,19 +19,6 @@ class TestNEDSource(unittest.TestCase):
         self.assertTrue(bbox is not None)
         self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
 
-    def test_img_file_name_parsing_topo(self):
-        fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_topobathy_2010.img'
-        n = ned_topo.create(FAKE_OPTIONS)
-        bbox = n.base._ned_parse_filename(fname)
-        self.assertTrue(bbox is not None)
-        self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
-
-    def test_none_file_name_parsing_topo(self):
-        fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_2010.img'
-        n = ned_topo.create(FAKE_OPTIONS)
-        bbox = n.base._ned_parse_filename(fname)
-        self.assertTrue(bbox is None)
-
     def test_zip_file_name_parsing_normal_topo_2(self):
         fname = 'ned19_n38x00_w122x50_tx_cameronco06_cameronco_2003.zip'
         n = ned_topo.create(FAKE_OPTIONS)
@@ -39,13 +27,6 @@ class TestNEDSource(unittest.TestCase):
 
     def test_zip_file_name_parsing_normal(self):
         fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_2010.zip'
-        n = ned.create(FAKE_OPTIONS)
-        bbox = n.base._ned_parse_filename(fname)
-        self.assertTrue(bbox is not None)
-        self.assertEqual((-122.5, 37.75, -122.25, 38.0), bbox.bounds)
-
-    def test_img_file_name_parsing_normal(self):
-        fname = 'ned19_n38x00_w122x50_ca_sanfrancisco_2010.img'
         n = ned.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is not None)
@@ -63,3 +44,41 @@ class TestNEDSource(unittest.TestCase):
         n = ned.create(FAKE_OPTIONS)
         bbox = n.base._ned_parse_filename(fname)
         self.assertTrue(bbox is None)
+
+    def test_roundtrip_name(self):
+        for fname in [
+                'ned19_n45x50_w097x75_sd_marshallco_2010.zip',
+                'ned19_n47x25_w097x50_nd_redriver_g_2008.zip',
+                'ned19_n47x25_w068x75_me_aroostook_2012.zip',
+                'ned19_n40x50_w098x50_ne_rainwater_2009.zip',
+                'ned19_n39x50_w095x25_ks_leavenworth_2010.zip',
+                'ned19_n43x50_w070x75_me_cumberlandcoast_2006.zip',
+                'ned19_n35x50_w096x75_ok_potawatomie_2011.zip',
+                'ned19_n46x00_w120x25_or_wa_id_columbiariver_2010.zip',
+                'ned19_n38x00_w122x25_ca_sanfrancisocoast_2010.zip',
+                'ned19_n38x00_w076x25_md_somersetwicomicocos_2012.zip',
+                'ned19_n41x00_w084x50_oh_north_2006.zip',
+                'ned19_n43x00_w095x75_ia_northwest_2008.zip',
+                'ned19_n47x00_w122x00_wa_lewis_2009.zip',
+                'ned19_n31x25_w091x75_la_statewide_2006.zip',
+                'ned19_n43x75_w092x25_mn_9southeastcounties_2008.zip',
+                'ned19_n40x25_w080x25_pa_southwest_2006.zip',
+                'ned19_n60x50_w150x25_ak_kenaicnt_10ft_2008.zip',
+                'ned19_n35x75_w077x75_nc_statewide_2003.zip',
+                'ned19_n34x75_w083x75_ga_lanierlake_2010.zip',
+                'ned19_n30x75_w082x25_ga_warecharltonco_2010.zip',
+                'ned19_n28x75_w081x00_fl_volusiaco_2006.zip',
+                'ned19_n32x50_w093x25_la_statewide_2006.zip',
+                'ned19_n33x00_w084x25_ga_potatocreek_2009.zip',
+                'ned19_n39x25_w086x50_in_bartholomew_jacksoncos_2011.zip',
+                'ned19_n30x00_w082x00_fl_clayputnam_2007.zip',
+                'ned19_n38x00_w112x75_ut_cedarvalley_2011.zip',
+                'ned19_n30x00_w082x75_fl_suwanneeriver_7a4_2013.zip',
+                'ned19_n39x25_w096x50_ks_gearyco_2010.zip',
+                'ned19_n42x25_w096x00_ia_south_westcentral_2008.zip',
+                'ned19_n43x00_w083x50_mi_oaklandco_2008.zip',
+        ]:
+            t = ned_base._parse_ned_tile(fname, None)
+            self.assertTrue(t is not None, fname)
+            f = t.zip_name()
+            self.assertTrue(fname, f)

--- a/tests/test_ned.py
+++ b/tests/test_ned.py
@@ -81,4 +81,4 @@ class TestNEDSource(unittest.TestCase):
             t = ned_base._parse_ned_tile(fname, None)
             self.assertTrue(t is not None, fname)
             f = t.zip_name()
-            self.assertTrue(fname, f)
+            self.assertEqual(fname, f)

--- a/tests/test_terrarium.py
+++ b/tests/test_terrarium.py
@@ -13,13 +13,15 @@ class TestTerrariumTiles(unittest.TestCase):
                         terrarium._parse_tile(tile_name))
 
     def test_location_to_xy(self):
-        x, y = terrarium._lonlat_to_xy(19, -122.39199, 37.79123)
+        t = terrarium.Terrarium([], [])
+        x, y = t.lonlat_to_xy(19, -122.39199, 37.79123)
         self.assertEqual(83897, x)
         self.assertEqual(202618, y)
 
     def test_projections(self):
+        t = terrarium.Terrarium([], [])
         z, x, y = (13, 1308, 3165)
-        ll_bbox = terrarium._latlon_bbox(z, x, y)
+        ll_bbox = t.latlon_bbox(z, x, y)
         cx = 0.5 * (ll_bbox.bounds[0] + ll_bbox.bounds[2])
         cy = 0.5 * (ll_bbox.bounds[1] + ll_bbox.bounds[3])
-        self.assertEqual((x, y), terrarium._lonlat_to_xy(z, cx, cy))
+        self.assertEqual((x, y), t.lonlat_to_xy(z, cx, cy))


### PR DESCRIPTION
This change allows sources to build a set of VRTs on the fly. This means that the NED source can return a separate VRT for each named region, meaning that the data from each can be used. Previously, they'd all been in the same VRT, which didn't allow for compositing between overlapping parts of differently-named regions.

This also adds an index to the tiles during generation to speed up intersection tests against them.

@rmarianski could you review, please?

Connects to #3.