### PR TITLE
Add 3-channel 16.8 fixed-point PNGs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,7 +16,6 @@ outputs:
   - type: skadi
   - type: terrarium
     zooms: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    enable_browser_png: true
 sources:
   - type: etopo1
     url: https://www.ngdc.noaa.gov/mgg/global/relief/ETOPO1/data/bedrock/grid_registered/georeferenced_tiff/ETOPO1_Bed_g_geotiff.zip

--- a/joerd/composite.py
+++ b/joerd/composite.py
@@ -52,7 +52,8 @@ def _mk_image(src_ds, dst_ds, mask_negative, filter_type):
 
 
 _NUMPY_TYPES = {
-    gdal.GDT_Int16: numpy.int16
+    gdal.GDT_Int16: numpy.int16,
+    gdal.GDT_Float32: numpy.float32
 }
 
 

--- a/joerd/output/terrarium.py
+++ b/joerd/output/terrarium.py
@@ -16,6 +16,12 @@ import numpy
 
 HALF_ARC_SEC = (1.0/3600.0)*.5
 TILE_NAME_PATTERN = re.compile('^([0-9]+)/([0-9]+)/([0-9]+)$')
+# first tried using the minimum value for this, but it doesn't seem to stay
+# stable, and the slightest change is enough to make it != nodata, which sets
+# it to "some" data.
+# so now using a nice "round" number, which should be less prone to precision
+# truncation issues (since all the precision bits are zero).
+FLT_NODATA = -3.0e38
 
 
 def _tile_name(z, x, y):
@@ -110,15 +116,16 @@ class TerrariumTile:
         dst_srs = osr.SpatialReference()
         dst_srs.ImportFromEPSG(3857)
 
-        dst_drv = gdal.GetDriverByName("GTiff")
-        dst_ds = dst_drv.Create(outfile, dst_x_size, dst_y_size, 1, gdal.GDT_Int16)
+        dst_drv = gdal.GetDriverByName("MEM")
+        dst_ds = dst_drv.Create('', dst_x_size, dst_y_size, 1, gdal.GDT_Float32)
+
         dst_x_res = float(dst_bbox[2] - dst_bbox[0]) / dst_x_size
         dst_y_res = float(dst_bbox[3] - dst_bbox[1]) / dst_y_size
         dst_gt = (dst_bbox[0], dst_x_res, 0,
                   dst_bbox[3], 0, -dst_y_res)
         dst_ds.SetGeoTransform(dst_gt)
         dst_ds.SetProjection(dst_srs.ExportToWkt())
-        dst_ds.GetRasterBand(1).SetNoDataValue(-32768)
+        dst_ds.GetRasterBand(1).SetNoDataValue(FLT_NODATA)
 
         # figure out what the approximate scale of the output image is in
         # lat/lon coordinates. this is used to select the appropriate filter.
@@ -128,42 +135,64 @@ class TerrariumTile:
 
         composite.compose(self, dst_ds, logger, min(ll_x_res, ll_y_res))
 
+        # we want the output to be 3-channels R, G, B with:
+        #   uheight = height + 32768.0
+        #   R = int(height) / 256
+        #   G = int(height) % 256
+        #   B = int(frac(height) * 256)
+        # Looks like gdal doesn't handle "nodata" across multiple channels,
+        # so we'll use R=0, which corresponds to height < 32,513 which is
+        # lower than any depth on Earth, so we should be okay.
         mem_drv = gdal.GetDriverByName("MEM")
-        mem_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, gdal.GDT_UInt16)
+        mem_ds = mem_drv.Create('', dst_x_size, dst_y_size, 3, gdal.GDT_Byte)
         mem_ds.SetGeoTransform(dst_gt)
         mem_ds.SetProjection(dst_srs.ExportToWkt())
         mem_ds.GetRasterBand(1).SetNoDataValue(0)
 
-        # convert from int16 to uint16 by shifting everything +32768. note that
-        # the conversion relies on uint16's wrap-around overflow behaviour.
-        # see this for more information:
-        # http://stackoverflow.com/questions/7715406/how-can-i-efficiently-transform-a-numpy-int8-array-in-place-to-a-value-shifted-n
         pixels = dst_ds.GetRasterBand(1).ReadAsArray(0, 0, dst_x_size, dst_y_size)
-        pixels = pixels.view(numpy.uint16)
-        pixels += 32768
-        res = mem_ds.GetRasterBand(1).WriteArray(pixels)
+        # transform to uheight, clamping the range
+        pixels += 32768.0
+        numpy.clip(pixels, 0.0, 65535.0, out=pixels)
+
+        r = (pixels / 256).astype(numpy.uint8)
+        res = mem_ds.GetRasterBand(1).WriteArray(r)
+        assert res == gdal.CPLE_None
+
+        g = (pixels % 256).astype(numpy.uint8)
+        res = mem_ds.GetRasterBand(2).WriteArray(g)
+        assert res == gdal.CPLE_None
+
+        b = ((pixels * 256) % 256).astype(numpy.uint8)
+        res = mem_ds.GetRasterBand(3).WriteArray(b)
+        assert res == gdal.CPLE_None
 
         png_file = os.path.join(self.parent.output_dir, tile + ".png")
         png_drv = gdal.GetDriverByName("PNG")
         png_ds = png_drv.CreateCopy(png_file, mem_ds)
 
-        # "browser" PNG is an image which will display okay in the browser. this
-        # can be very useful for demos, or checking that the data is looking
-        # okay. it's perhaps less useful for "production" use, so is disabled by
-        # default.
-        if self.parent.enable_browser_png:
-            pixels = (numpy.clip(pixels, 31768, 34317) - 31768) / 10
-            mem2_ds = mem_drv.Create('', dst_x_size, dst_y_size, 1, gdal.GDT_Byte)
-            mem2_ds.SetGeoTransform(dst_gt)
-            mem2_ds.SetProjection(dst_srs.ExportToWkt())
-            mem2_ds.GetRasterBand(1).SetNoDataValue(0)
-            mem2_ds.GetRasterBand(1).WriteArray(pixels)
-            png2_file = os.path.join(self.parent.output_dir, tile + ".u8.png")
-            png2_ds = png_drv.CreateCopy(png2_file, mem2_ds)
+        # TIFF compresses best if we stick to integer pixels, using LZW
+        # and the "2" type predictor. we might be able to keep some bits
+        # of precision with float32 and DISCARD_LSB, but that's only
+        # available in GDAL >= 2.0
+        tif_drv = gdal.GetDriverByName("GTiff")
+        tif_ds = tif_drv.Create(outfile, dst_x_size, dst_y_size, 1,
+                                gdal.GDT_Int16, options = [
+                                    'COMPRESS=LZW',
+                                    'PREDICTOR=2'
+                                ])
+        tif_ds.SetGeoTransform(dst_gt)
+        tif_ds.SetProjection(dst_srs.ExportToWkt())
+        tif_ds.GetRasterBand(1).SetNoDataValue(-32768)
 
-            del mem2_ds
-            del png2_ds
+        pixels = dst_ds.GetRasterBand(1).ReadAsArray(0, 0, dst_x_size, dst_y_size)
+        # transform to integer height, clamping the range
+        numpy.clip(pixels, -32768, 32767, out=pixels)
+        tif_ds.GetRasterBand(1).WriteArray(pixels.astype(numpy.int16))
 
+        # explicitly delete the datasources. the Python-GDAL docs suggest that
+        # this is a good idea not only to dispose of memory buffers but also
+        # to ensure that the backing file handles are closed.
+        del tif_ds
         del dst_ds
         del mem_ds
         del png_ds


### PR DESCRIPTION
Replace browser PNG with a 3-channel RGB 16.8 fixed point height format. Make GeoTIFF output compressed (LZW, predictor=2).

![image](https://cloud.githubusercontent.com/assets/271360/13084601/dfaaeb10-d4d1-11e5-92b6-e3d789f24d63.png)

Note that the blockiness around the coast is flipping between 0, which is non-greenish (green channel = 0), and small negative numbers which are very greenish (green > 200-ish). It looks horrible, but isn't actually a bug. (Although we might want to come back to it far, far down the line when we've solved all the other problems).

Connects to #30.

@rmarianski could you review, please?