### PR TITLE
Use the power of the Einstein Sum for a 300x speedup.

### DIFF
--- a/joerd/output/normal.py
+++ b/joerd/output/normal.py
@@ -227,8 +227,9 @@ class NormalTile:
         # copy the norm value out into RGB components.
         norm_copy = norm[:, :, numpy.newaxis]
 
-        # then we squash that into the range (0, 1) and scale it out to
-        # (0, 255) for use as a uint8.
+        # dividing the img by norm_copy should give us RGB components with
+        # values between -1 and 1, but we need values between 0 and 255 for
+        # PNG channels. so we move and scale the values to fit in that range.
         scaled = (128.0 * (img / norm_copy + 1.0))
 
         # and finally clip it to (0, 255) just in case


### PR DESCRIPTION
Profiling revealed that the normalisation step was taking the most time. The normalisation step takes the _x_ & _y_ gradients together with a unit _z_ normal and turns that into a unit 3-vector scaled between 0 and 255 (with 0, 0, 0 -> 128, 128, 128). Previously, it was using `apply_along_axis`, but this turns out to be a Bad Idea. Instead, using vector operations the whole way along is (in a microbenchmark) about 320x faster, but it seems that the inner sum of a 3D matrix isn't supported by `numpy.norm`, so we have to use Einstein Sum notation, which looks a bit like magic.

@rmarianski, @kevinkreiser could you review, please?
