### PR TITLE
Make coastal blockiness a bit better

### DIFF
--- a/joerd/download.py
+++ b/joerd/download.py
@@ -1,4 +1,4 @@
-from contextlib import contextmanager, closing
+from contextlib2 import contextmanager, closing
 import urllib2
 import tempfile
 import os

--- a/joerd/mask.py
+++ b/joerd/mask.py
@@ -1,0 +1,106 @@
+from osgeo import gdal
+import numpy
+import numpy.ma
+
+def negative(src_filename, dst_driver, dst_filename):
+    """
+    Processes a raster which has valid positive heights, but invalid heights
+    at less than or equal to zero. These zero or negative heights are masked
+    to NODATA, and the file is written to dst_filename using dst_driver.
+    """
+
+    src_ds = gdal.Open(src_filename)
+    mem_drv = gdal.GetDriverByName("MEM")
+    ds = mem_drv.CreateCopy('', src_ds)
+    x_size = ds.RasterXSize
+    y_size = ds.RasterYSize
+
+    band = ds.GetRasterBand(1)
+    nodata = band.GetNoDataValue()
+
+    data = band.ReadAsArray(0, 0, x_size, y_size)
+    mask = (data <= 0) | (data == nodata)
+    mx = numpy.ma.masked_array(data, mask=mask)
+    res = band.WriteArray(numpy.ma.filled(mx, nodata))
+    assert res == gdal.CPLE_None
+
+    drv = gdal.GetDriverByName(dst_driver)
+    dst_ds = drv.CreateCopy(dst_filename, ds)
+
+    del dst_ds
+    del ds
+    del src_ds
+
+
+def raster(src_filename, msk_filename, mask_value, dst_driver, dst_filename):
+    """
+    Processes a raster which is masked by a particular value of another raster.
+    Both must be downloaded, but then they are masked at source - which
+    requires both to be the same size, location and in the same projection.
+    """
+
+    orig_ds = gdal.Open(src_filename)
+    mem_drv = gdal.GetDriverByName("MEM")
+    src_ds = mem_drv.CreateCopy('', orig_ds)
+    msk_ds = gdal.Open(msk_filename)
+
+    x_size = src_ds.RasterXSize
+    y_size = src_ds.RasterYSize
+    assert x_size == msk_ds.RasterXSize
+    assert y_size == msk_ds.RasterYSize
+    assert src_ds.GetProjection() == msk_ds.GetProjection()
+    assert src_ds.GetGeoTransform() == msk_ds.GetGeoTransform()
+
+    src_band = src_ds.GetRasterBand(1)
+    src_nodata = src_band.GetNoDataValue()
+
+    src_data = src_band.ReadAsArray(0, 0, x_size, y_size)
+    msk_data = msk_ds.GetRasterBand(1).ReadAsArray(0, 0, x_size, y_size)
+    mask = (msk_data == mask_value)
+    mx = numpy.ma.masked_array(src_data, mask=mask)
+    res = src_band.WriteArray(numpy.ma.filled(mx, src_nodata))
+    assert res == gdal.CPLE_None
+
+    drv = gdal.GetDriverByName(dst_driver)
+    dst_ds = drv.CreateCopy(dst_filename, src_ds)
+
+    del dst_ds
+    del msk_ds
+    del src_ds
+    del orig_ds
+
+
+def raw(src_filename, raw_filename, raw_value, dst_driver, dst_filename):
+    """
+    Processes a raster which is masked by a particular value of a raw file.
+    Both must be downloaded, but then they are masked at source - which
+    requires both to be the same size, location and in the same projection.
+    """
+
+    orig_ds = gdal.Open(src_filename)
+    mem_drv = gdal.GetDriverByName("MEM")
+    src_ds = mem_drv.CreateCopy('', orig_ds)
+
+    x_size = src_ds.RasterXSize
+    y_size = src_ds.RasterYSize
+
+    raw_data = numpy.reshape(numpy.fromfile(raw_filename, dtype=numpy.uint8),
+                             (y_size, x_size), order='C')
+    assert x_size == raw_data.shape[1]
+    assert y_size == raw_data.shape[0]
+
+    src_band = src_ds.GetRasterBand(1)
+    src_nodata = src_band.GetNoDataValue()
+
+    src_data = src_band.ReadAsArray(0, 0, x_size, y_size)
+    mask = (raw_data == raw_value)
+    mx = numpy.ma.masked_array(src_data, mask=mask)
+    res = src_band.WriteArray(numpy.ma.filled(mx, src_nodata))
+    assert res == gdal.CPLE_None
+
+    drv = gdal.GetDriverByName(dst_driver)
+    dst_ds = drv.CreateCopy(dst_filename, src_ds)
+
+    del dst_ds
+    del src_ds
+    del orig_ds

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -2,7 +2,6 @@ from joerd.util import BoundingBox
 import joerd.download as download
 import joerd.check as check
 import joerd.srs as srs
-from contextlib import closing
 from shutil import copyfile
 import os.path
 import os
@@ -53,8 +52,8 @@ class ETOPO1(object):
     def output_file(self):
         return os.path.join(self.base_dir, self.target_name)
 
-    def url(self):
-        return self.etopo1_url
+    def urls(self):
+        return [self.etopo1_url]
 
     def options(self):
         return self.download_options
@@ -68,9 +67,6 @@ class ETOPO1(object):
 
     def srs(self):
         return srs.wgs84()
-
-    def mask_negative(self):
-        return False
 
     def filter_type(self, src_res, dst_res):
         return gdal.GRA_Lanczos

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -121,7 +121,9 @@ class GMTED(object):
         return True
 
     def filter_type(self, src_res, dst_res):
-        return gdal.GRA_Lanczos if src_res > dst_res else gdal.GRA_Cubic
+        # seems like GRA_Lanczos has trouble with nodata, which is causing
+        # "ringing" near the edges of the data.
+        return gdal.GRA_Bilinear if src_res > dst_res else gdal.GRA_Cubic
 
     def _parse_bbox(self, ns_deg, is_ns, ew_deg, is_ew, res):
         bottom = int(ns_deg)

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -2,8 +2,8 @@ from joerd.util import BoundingBox
 import joerd.download as download
 import joerd.check as check
 import joerd.srs as srs
+import joerd.mask as mask
 from multiprocessing import Pool
-from contextlib import closing
 from shutil import copyfileobj
 import os.path
 import os
@@ -44,11 +44,11 @@ class GMTEDTile(object):
         return "%(y)s%(x)s_20101117_gmted_mea%(res)s.tif" % \
             dict(res=res, x=xname, y=yname)
 
-    def url(self):
+    def urls(self):
         dir = "%s%03d" % ("E" if self.x >= 0 else "W", abs(self.x))
         res = self._res()
         dname = "/%(res)sdarcsec/mea/%(dir)s/" % dict(res=res, dir=dir)
-        return self.parent.url + dname + self._file_name()
+        return [self.parent.url + dname + self._file_name()]
 
     def verifier(self):
         return check.is_gdal
@@ -61,8 +61,7 @@ class GMTEDTile(object):
         return os.path.join(self.parent.base_dir, fname)
 
     def unpack(self, tmp):
-        with open(self.output_file(), 'w') as out:
-            copyfileobj(tmp, out)
+        mask.negative(tmp.name, "GTiff", self.output_file())
 
 
 class GMTED(object):
@@ -116,9 +115,6 @@ class GMTED(object):
 
     def srs(self):
         return srs.wgs84()
-
-    def mask_negative(self):
-        return True
 
     def filter_type(self, src_res, dst_res):
         # seems like GRA_Lanczos has trouble with nodata, which is causing

--- a/joerd/source/ned.py
+++ b/joerd/source/ned.py
@@ -15,7 +15,7 @@ class NED(object):
         options = options.copy()
         options['pattern'] = NORMAL_PATTERN
         options['base_dir'] = options.get('base_dir', 'ned')
-        self.base = NEDBase(options)
+        self.base = NEDBase(False, options)
 
     def get_index(self):
         return self.base.get_index()
@@ -28,9 +28,6 @@ class NED(object):
 
     def filter_type(self, src_res, dst_res):
         return self.base.filter_type(src_res, dst_res)
-
-    def mask_negative(self):
-        return True
 
     def srs(self):
         return self.base.srs()

--- a/joerd/source/ned_topobathy.py
+++ b/joerd/source/ned_topobathy.py
@@ -15,7 +15,7 @@ class NEDTopobathy(object):
         options = options.copy()
         options['pattern'] = TOPOBATHY_PATTERN
         options['base_dir'] = options.get('base_dir', 'ned_topobathy')
-        self.base = NEDBase(options)
+        self.base = NEDBase(True, options)
 
     def get_index(self):
         return self.base.get_index()
@@ -28,9 +28,6 @@ class NEDTopobathy(object):
 
     def filter_type(self, src_res, dst_res):
         return self.base.filter_type(src_res, dst_res)
-
-    def mask_negative(self):
-        return False
 
     def srs(self):
         return self.base.srs()

--- a/joerd/tmpdir.py
+++ b/joerd/tmpdir.py
@@ -1,0 +1,16 @@
+import tempfile
+import shutil
+from contextlib2 import contextmanager
+
+
+# Equivalent of NamedTemporaryFile, but for directories. Will completely
+# remove the directory on exit.
+@contextmanager
+def tmpdir():
+    path = tempfile.mkdtemp()
+
+    try:
+        yield path
+
+    finally:
+        shutil.rmtree(path, ignore_errors=True)

--- a/joerd/vrt.py
+++ b/joerd/vrt.py
@@ -1,5 +1,5 @@
 from osgeo import gdal
-from contextlib import contextmanager, closing
+from contextlib2 import contextmanager, closing
 import subprocess
 import tempfile
 import logging

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='joerd',
           'pyqtree',
           'geographiclib',
           'boto3',
-          'distutils',
+          'contextlib2',
       ],
       test_suite='tests',
       tests_require=[


### PR DESCRIPTION
Some of the blockiness was coming from using GMTED data with NODATA set in water areas. At zoom 11, it was scaling up and interpolating using the Lanczos filter, which doesn't behave well in the presence of NODATA. Using Bilinear more or less solves this, at the cost of it not looking so great - but it's only intended as backfill for SRTM anyway.

SRTM blockiness was coming from false data in water areas. SRTM ships a "water body" mask raster, so this is now used to mask the water areas. As part of this, the masking step was moved to be part of the download, and now operates at the native resolution of the input dataset.

Sadly, this doesn't solve the problem entirely. For example,

![image](https://cloud.githubusercontent.com/assets/271360/13286164/3fc9b6ae-daf7-11e5-8799-62eb04de066f.png)

The blockiness around the coastline now is due to resampling errors. But it's better than it was before. I've added #41 to track this.

Connects to #36.

@rmarianski could you review, please?