### PR TITLE
Remove Unneeded Cached DEMs

### DIFF
--- a/joerd/command.py
+++ b/joerd/command.py
@@ -41,18 +41,15 @@ def lock_array(a, **opts):
     finally:
         a.release()
 
-def _make_space(handles, path):
+def _make_space(tmps, path):
     #if theres nothing to do bail
     with lock_array(_superfluous, block=True) as superfluous:
         if len(superfluous) and not superfluous[len(superfluous) - 1]:
             raise Exception('Need more space but nothing superfluous to delete')
-        #assume unpacking will need 3x the space
+        #assume unpacking will need at least this much space
         needed = 0
-        for h in handles:
-            position = h.tell();
-            h.seek(0, os.SEEK_END)
-            needed += h.tell()
-            h.seek(position, os.SEEK_SET)
+        for t in tmps:
+            needed += os.path.getsize(t.name)
         #keep removing stuff until we have enough
         remaining = _remaining_disk(path)
         for i in range(len(superfluous)):

--- a/joerd/command.py
+++ b/joerd/command.py
@@ -76,6 +76,10 @@ def _init_processes(s, l):
     global _logger
     _logger = l
 
+    # make sure process will error if GDAL fails
+    gdal.UseExceptions()
+
+
 def _download(d):
     try:
         options = d.options().copy()
@@ -395,5 +399,8 @@ def joerd_main(argv=None):
         config_dir = os.path.dirname(args.config)
         logconfig_path = os.path.join(config_dir, cfg.logconfig)
         logging.config.fileConfig(logconfig_path)
+
+    # make sure process will error if GDAL fails
+    gdal.UseExceptions()
 
     args.func(cfg)

--- a/joerd/command.py
+++ b/joerd/command.py
@@ -1,7 +1,7 @@
 from config import make_config_from_argparse
 from osgeo import gdal
 from importlib import import_module
-from multiprocessing import Pool, Array, cpu_count
+from multiprocessing import Pool, Array
 import joerd.download as download
 import joerd.tmpdir as tmpdir
 import sys
@@ -50,7 +50,6 @@ def _make_space(tmps, path):
         needed = 0
         for t in tmps:
             needed += os.path.getsize(t.name)
-        needed *= 3 * cpu_count()
         #keep removing stuff until we have enough
         remaining = _remaining_disk(path)
         for i in range(len(superfluous)):

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -31,6 +31,10 @@ class ETOPO1(object):
         if not os.path.isdir(self.base_dir):
             os.makedirs(self.base_dir)
 
+    def existing_files(self):
+        if os.path.exists(self.output_file()):
+            yield self.output_file()
+
     def downloads_for(self, tile):
         # There's just one thing to download, and it's this single world
         # tile.

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -80,6 +80,12 @@ class GMTED(object):
         if not os.path.isdir(self.base_dir):
             os.makedirs(self.base_dir)
 
+    def existing_files(self):
+        for base, dirs, files in os.walk(self.base_dir):
+            for f in  files:
+                if f.endswith('tif'):
+                    yield os.path.join(base, f)
+
     def downloads_for(self, tile):
         tiles = set()
         # if the tile scale is greater than 20x the GMTED scale, then there's no

--- a/joerd/source/ned.py
+++ b/joerd/source/ned.py
@@ -20,6 +20,9 @@ class NED(object):
     def get_index(self):
         return self.base.get_index()
 
+    def existing_files(self):
+        return self.base.existing_files()
+
     def downloads_for(self, tile):
         return self.base.downloads_for(tile)
 

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -172,7 +172,7 @@ class NEDBase(object):
     def existing_files(self):
         for base, dirs, files in os.walk(self.base_dir):
             for f in  files:
-                if f.endswith('img') or f.endswith('xml'):
+                if f.endswith('img'):
                     yield os.path.join(base, f)
 
     def downloads_for(self, tile):

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -171,7 +171,7 @@ class NEDBase(object):
 
     def existing_files(self):
         for base, dirs, files in os.walk(self.base_dir):
-            for f in  files:
+            for f in files:
                 if f.endswith('img'):
                     yield os.path.join(base, f)
 

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -169,6 +169,12 @@ class NEDBase(object):
 
         return self.tile_index
 
+    def existing_files(self):
+        for base, dirs, files in os.walk(self.base_dir):
+            for f in  files:
+                if f.endswith('img') or f.endswith('xml'):
+                    yield os.path.join(base, f)
+
     def downloads_for(self, tile):
         tiles = set()
         # if the tile scale is greater than 20x the NED scale, then there's no

--- a/joerd/source/ned_topobathy.py
+++ b/joerd/source/ned_topobathy.py
@@ -20,6 +20,9 @@ class NEDTopobathy(object):
     def get_index(self):
         return self.base.get_index()
 
+    def existing_files(self):
+        return self.base.existing_files()
+
     def downloads_for(self, tile):
         return self.base.downloads_for(tile)
 

--- a/joerd/source/srtm.py
+++ b/joerd/source/srtm.py
@@ -135,6 +135,12 @@ class SRTM(object):
 
         return self.tile_index
 
+    def existing_files(self):
+        for base, dirs, files in os.walk(self.base_dir):
+            for f in  files:
+                if f.endswith('hgt'):
+                    yield os.path.join(base, f)
+
     def downloads_for(self, tile):
         tiles = set()
         # if the tile scale is greater than 20x the SRTM scale, then there's no


### PR DESCRIPTION
..when the current job needs more space than you have.

This fixes #40.

The way it works is by having each datasource generate a list of its cached DEMs, we then subtract from this set the set required by the current job. What remains is a list of DEMs that we could remove if we need the space. We save this list in shared memory and in a synchronized manner, we delete these files when the `unpack` operation fails.

We still need to catch just the exception thrown by unpacking to a full disk though. I'm still testing this so its not quite ready yet. Just wanted to show the diff for easier debugging.