### PR TITLE
Fix SRTM missing mask error

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,6 +28,7 @@ sources:
     tries: 100
   - type: srtm
     url: http://e4ftl01.cr.usgs.gov/SRTM/SRTMGL1.003/2000.02.11/
+    mask-url: http://e4ftl01.cr.usgs.gov/SRTM/SRTMSWBD.003/2000.02.11/
   - type: ned
     ftp_server: rockyftp.cr.usgs.gov
     base_path: vdelivery/Datasets/Staged/NED/19/IMG

--- a/joerd/source/srtm.py
+++ b/joerd/source/srtm.py
@@ -61,7 +61,15 @@ class SRTMTile(object):
     def output_file(self):
         return os.path.join(self.parent.base_dir, self.fname)
 
-    def unpack(self, data_zip, mask_zip):
+    def unpack(self, data_zip, mask_zip=None):
+        # if there's no mask, then just extract the SRTM as-is.
+        if mask_zip is None:
+            with zipfile.ZipFile(data_zip.name, 'r') as zfile:
+                zfile.extract(self.fname, self.parent.base_dir)
+            return
+
+        # otherwise, make a temporary directory to keep the SRTM and
+        # mask in while compositing them.
         with tmpdir.tmpdir() as d:
             with zipfile.ZipFile(data_zip.name, 'r') as zfile:
                 zfile.extract(self.fname, d)


### PR DESCRIPTION
The SRTM mask is optional, but when it's omitted only one argument is passed to the unpack function, which causes an error. This makes the second argument optional, and skips the masking step if it isn't specified.

@kevinkreiser could you review, please?