### PR TITLE
Fix a bunch of bugs, mostly related to clustering.

### DIFF
--- a/joerd/command.py
+++ b/joerd/command.py
@@ -364,15 +364,22 @@ def joerd_enqueuer(cfg):
         }
         queue.send_message(MessageBody=json.dumps(region))
 
+    # inset the boxes by an epsilon amount. this is so that they don't
+    # intersect neighbouring boxes, causing them to be rendered twice.
+    # 0.0001 is about 1/10th of a zoom 18 tile (in x direction), so
+    # should be large enough to avoid duplication, but small enough to
+    # ensure all the tiles we want are actually done.
+    epsilon = 0.0001
+
     # send messages for all the other bboxes that need rendering.
     for (x, y), max_z in bboxes.iteritems():
         region = {
             'zoom_range': [8, max_z],
             'bbox': {
-                'left': x,
-                'bottom': y,
-                'right': x + block_size,
-                'top': y + block_size,
+                'left': x + epsilon,
+                'bottom': y + epsilon,
+                'right': x + block_size - epsilon,
+                'top': y + block_size - epsilon,
             }
         }
         queue.send_message(MessageBody=json.dumps(region))

--- a/joerd/command.py
+++ b/joerd/command.py
@@ -366,10 +366,11 @@ def joerd_enqueuer(cfg):
 
     # inset the boxes by an epsilon amount. this is so that they don't
     # intersect neighbouring boxes, causing them to be rendered twice.
-    # 0.0001 is about 1/10th of a zoom 18 tile (in x direction), so
+    # 0.00015 is about 1/7th of a zoom 18 tile (in x direction), so
     # should be large enough to avoid duplication, but small enough to
-    # ensure all the tiles we want are actually done.
-    epsilon = 0.0001
+    # ensure all the tiles we want are actually done, taking into
+    # account the overlap between SRTM source tiles.
+    epsilon = 0.00015
 
     # send messages for all the other bboxes that need rendering.
     for (x, y), max_z in bboxes.iteritems():

--- a/joerd/config.py
+++ b/joerd/config.py
@@ -2,6 +2,7 @@ from yaml import load
 from util import BoundingBox
 from multiprocessing import cpu_count
 from joerd.region import Region
+import copy
 
 
 class Configuration(object):

--- a/joerd/output/normal.py
+++ b/joerd/output/normal.py
@@ -93,7 +93,7 @@ def _merc_bbox(z, x, y):
         MERCATOR_WORLD_SIZE * (0.5 - y / extent))
 
 
-class NormalTile:
+class NormalTile(object):
     def __init__(self, parent, z, x, y):
         self.parent = parent
         self.z = z

--- a/joerd/output/skadi.py
+++ b/joerd/output/skadi.py
@@ -50,15 +50,17 @@ def _parse_tile(tile_name):
     return None
 
 
-class SkadiTile:
+class SkadiTile(object):
     def __init__(self, parent, x, y):
         self.parent = parent
         self.x = x
         self.y = y
-        self.sources = []
 
     def set_sources(self, sources):
-        self.source = sources
+        logger = logging.getLogger('skadi')
+        logger.debug("Set sources on tile (x,y)=%r: %r"
+                     % ((self.x, self.y), [type(s).__name__ for s in sources]))
+        self.sources = sources
 
     def latlon_bbox(self):
         return _bbox(self.x, self.y)

--- a/joerd/output/terrarium.py
+++ b/joerd/output/terrarium.py
@@ -68,7 +68,7 @@ def _merc_bbox(z, x, y):
         MERCATOR_WORLD_SIZE * (0.5 - y / extent))
 
 
-class TerrariumTile:
+class TerrariumTile(object):
     def __init__(self, parent, z, x, y):
         self.parent = parent
         self.z = z

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -56,3 +56,7 @@ class S3Store(object):
                     s3_key = os.path.join(suffix, f)
                     bucket.upload_file(src_name, s3_key,
                                        Config=self.upload_config)
+
+
+def create(cfg):
+    return S3Store(cfg)

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -1,4 +1,5 @@
 import boto3
+from boto3.s3.transfer import TransferConfig
 from os import walk
 import os.path
 
@@ -57,6 +58,8 @@ class S3Store(object):
         if not d.endswith('/'):
             d = d + "/"
 
+        transfer_config = TransferConfig(**self.upload_config)
+
         for dirpath, dirs, files in walk(d):
             if dirpath.startswith(d):
                 suffix = dirpath[len(d):]
@@ -73,7 +76,7 @@ class S3Store(object):
                         extra_args['ContentType'] = mime
 
                     bucket.upload_file(src_name, s3_key,
-                                       Config=self.upload_config,
+                                       Config=transfer_config,
                                        ExtraArgs=extra_args)
 
 

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -70,7 +70,7 @@ class S3Store(object):
 
                     extra_args = {}
                     if mime:
-                        extra_args['Content-Type'] = mime
+                        extra_args['ContentType'] = mime
 
                     bucket.upload_file(src_name, s3_key,
                                        Config=self.upload_config,

--- a/tests/test_srtm.py
+++ b/tests/test_srtm.py
@@ -22,3 +22,10 @@ class TestSRTMSource(unittest.TestCase):
         bbox = s._parse_bbox(fname)
         self.assertTrue(bbox is not None)
         self.assertEqual((-122, 38, -121, 39), bbox.bounds)
+
+    def test_file_name_parsing_3(self):
+        fname = 'N37W116.SRTMSWBD.raw.zip'
+        s = srtm.create(FAKE_OPTIONS)
+        bbox = s._parse_bbox(fname)
+        self.assertTrue(bbox is not None)
+        self.assertEqual((-116, 37, -115, 38), bbox.bounds)


### PR DESCRIPTION
This:

* Fixes a bunch of typos and other code mistakes with the SQS / cluster functionality, including: missing the `create` function for the S3 'plugin', missing imports, incorrect usage of the boto3 API.
* Make bounding boxes for jobs slightly smaller than 2x2 degrees, so that they overlap all the tiles we want, but don't touch neighbouring ones which will be generated elsewhere. This reduces the size of the downloads and removes duplicate work.
* Fix typo with Skadi tiles, which was causing them to be generated blank.
* Add support for separate indexes for the data / mask for SRTM. This is because the SRTM masks are not generated / put up online when they are land-only.
* Add recovery mechanism for when a job fails - the queue will ensure it gets retried.

@kevinkreiser could you review, please?