### PR TITLE
Options for making smaller jobs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ python setup.py install
 Using
 -----
 
-Joerd installs as a command line library, and there is currently only one command:
+Joerd installs as a command line library, and there are currently three commands:
 
 * `process` reads the regions of interest from your config file, downloads all the sources to satisfy requests in that region, and for each tile intersecting the regions of interest in configured outputs, builds a [VRT](http://www.gdal.org/gdal_vrttut.html) "virtual dataset" of all relevant source files and generates the output image(s).
+* `server` starts up Joerd as a server listening for jobs on an SQS queue. It is intended for use as part of a cluster to parallelise very large job runs.
+* `enqueuer` reads a config file and outputs each region listed in the `regions` of the configuration file as a separate job to an SQS queue. This is intended for filling the queue for `server` to get work out of.
+
+There is also a `script/generate.py` program to generate a configuration with lots of little jobs all split up.
 
 To run a command, type something like this:
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -80,15 +80,18 @@ if __name__ == '__main__':
                         type=parse_bbox)
     parser.add_argument("--global-region", help="Add a global, low-zoom job "
                         "to the output.", default=False)
+    parser.add_argument("--global-mask", help="Add a shape which covers the "
+                        "whole input bbox to generate every tile.",
+                        default=False)
 
     parser.add_argument("input-file", help="Config YAML file to read as "
                         "input. Its 'regions' section will be replaced.")
     parser.add_argument("output-file", help="Config YAML to write, with "
                         "replaced 'regions'.")
     parser.add_argument("shape-file", help="Shape file(s) to use. Jobs "
-                        "will not be generated where they do not "
-                        "intersect some item from one of these.",
-                        nargs='+')
+                        "will only be generated where they intersect some "
+                        "item from one of these.",
+                        nargs='*')
 
     args = vars(parser.parse_args())
 
@@ -107,6 +110,9 @@ if __name__ == '__main__':
     objs = []
     for shapefile in args['shape-file']:
         objs.extend(ogrWkt2Shapely(shapefile))
+
+    if args['global_mask']:
+        objs.append(box(*bbox))
 
     print "Building index..."
     index = pyqtree.Index(bbox=[-180,-90,180,90])

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,0 +1,150 @@
+from osgeo import ogr
+from yaml import load, dump
+from copy import deepcopy
+from shapely.wkt import loads
+from shapely.geometry import box
+import pyqtree
+import argparse
+import math
+
+
+# convert OGR readable format to WKT representation
+def ogrWkt2Shapely(input_shape):
+    # this throws away the other attributes of the feature, but is
+    # sufficient in this use case
+    shapely_objects=[]
+    shp = ogr.Open(input_shape)
+    lyr = shp.GetLayer()
+    for n in range(0, lyr.GetFeatureCount()):
+        feat = lyr.GetFeature(n)
+        wkt_feat = loads(feat.geometry().ExportToWkt())
+        shapely_objects.append(wkt_feat)
+    return shapely_objects
+
+
+def make_regions(x, y, stride, sub_block_size):
+    regions = list()
+
+    # inset the boxes by an epsilon amount. this is so that they don't
+    # intersect neighbouring boxes, causing them to be rendered twice.
+    # 0.00015 is about 1/7th of a zoom 18 tile (in x direction), so
+    # should be large enough to avoid duplication, but small enough to
+    # ensure all the tiles we want are actually done, taking into
+    # account the overlap between SRTM source tiles.
+    epsilon = 0.00015
+
+    # one "top level" region for each skadi tile. this will involve some
+    # overlap for the terrarium tiles, sadly.
+    for dx in range(0, stride):
+        for dy in range(0, stride):
+            regions.append(dict(
+                bbox=dict(
+                    left=(x+dx+epsilon), bottom=(y+dy+epsilon),
+                    right=(x+dx+1-epsilon), top=(y+dy+1-epsilon)),
+                zoom_range=[8,13]))
+
+    # for each smaller block of tiles, do zooms 14 & 15 too
+    sub_block_width = float(stride) / sub_block_size
+    for ix in range(0, sub_block_size):
+        for iy in range(0, sub_block_size):
+            regions.append(dict(
+                bbox=dict(
+                    left=(x+ix*sub_block_width+epsilon),
+                    bottom=(y+iy*sub_block_width+epsilon),
+                    right=(x+(ix+1)*sub_block_width-epsilon),
+                    top=(y+(iy*1)*sub_block_width-epsilon)),
+                zoom_range=[14,16]))
+
+    return regions
+
+
+def parse_bbox(value):
+    bbox = value.split(',')
+    if len(bbox) != 4:
+        raise argparse.ArgumentError
+    return map(float, bbox)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--sub-block-size", help="How many blocks, in "
+                        "each direction, to split regions smaller than "
+                        "a Skadi tile into.", default=3)
+    parser.add_argument("--stride", help="How large is a block? This "
+                        "should be no smaller than 1 degree.",
+                        default=1)
+    parser.add_argument("--bbox", help="Bounding box to limit the extent of "
+                        "job creation, expressed as left,bottom,right,top.",
+                        default=[-180,-90,180,90], action='store',
+                        type=parse_bbox)
+    parser.add_argument("--global-region", help="Add a global, low-zoom job "
+                        "to the output.", default=False)
+
+    parser.add_argument("input-file", help="Config YAML file to read as "
+                        "input. Its 'regions' section will be replaced.")
+    parser.add_argument("output-file", help="Config YAML to write, with "
+                        "replaced 'regions'.")
+    parser.add_argument("shape-file", help="Shape file(s) to use. Jobs "
+                        "will not be generated where they do not "
+                        "intersect some item from one of these.",
+                        nargs='+')
+
+    args = vars(parser.parse_args())
+
+    stride = args['stride']
+    sub_block_size = args['sub_block_size']
+
+    bbox = args['bbox']
+    bbox[0] = stride * int(math.floor(bbox[0] / stride))
+    bbox[1] = stride * int(math.floor(bbox[1] / stride))
+    bbox[2] = stride * int(math.ceil(bbox[2] / stride))
+    bbox[3] = stride * int(math.ceil(bbox[3] / stride))
+
+    conf = load(open(args['input-file']))
+
+    print "Loading shapefiles..."
+    objs = []
+    for shapefile in args['shape-file']:
+        objs.extend(ogrWkt2Shapely(shapefile))
+
+    print "Building index..."
+    index = pyqtree.Index(bbox=[-180,-90,180,90])
+    for o in objs:
+        index.insert(item=o, bbox=o.bounds)
+
+    regions = list()
+    hit = 0
+    total = 0
+
+    if args['global_region']:
+        regions.append(dict(
+            bbox=dict(
+                left=-180,
+                bottom=-90,
+                right=180,
+                top=90),
+            zoom_range=[0,8]))
+
+    print "Intersecting inside bbox %r..." % bbox
+    for x in range(bbox[0], bbox[2], stride):
+        if total > 0:
+            print "   >> x = %d (%d/%d = %.1f%%)" \
+                % (x, hit, total, (100.0 * hit) / total)
+
+        for y in range(bbox[1], bbox[3], stride):
+            bb = [x, y, x + stride, y + stride]
+            b = box(*bb)
+            for o in index.intersect(bb):
+                if b.intersects(o):
+                    regions.extend(make_regions(x, y, stride,
+                                                sub_block_size))
+                    hit += 1
+                    break
+            total += 1
+
+    print "Done, writing new config."
+    conf['regions'] = dict(enumerate(regions))
+
+    with open(args['output-file'], 'w') as fh:
+        dump(conf, fh)


### PR DESCRIPTION
Removed complicated stuff from enqueuer and put it in a separate program, with more options to control output size.

It is now possible to run a config through the `scripts/generate.py`, for example:

```bash
python scripts/generate.py --bbox="-120,36,-118,40" config.yaml config.out.yaml ~/Downloads/natural_earth/ne_10m_*.shp
```

Will generate an output file with many smaller regions. The output config can be passed directly into the enqueuer, which will now just turn each into a job, 1:1.

Note that for production use, the `--bbox` parameter is optional and defaults to global scope. There's also a `--global-region True` argument for adding a global job to do everything below z8.

@kevinkreiser could you review, please?