### PR TITLE
actually iterate over configure regions

### DIFF
--- a/joerd/command.py
+++ b/joerd/command.py
@@ -325,7 +325,7 @@ def joerd_enqueuer(cfg):
     sqs = boto3.resource('sqs')
     queue = sqs.get_queue_by_name(QueueName=cfg.sqs_queue_name)
 
-    for r in cfg.regions.itervalues():
+    for r in cfg.yml['regions'].itervalues():
         queue.send_message(MessageBody=json.dumps(r))
 
     logger.info("Done.")


### PR DESCRIPTION
so the config has the orignal dict/list yaml loaded but it also has some proper objects in it. seems like the enqueue method wanted to loop over the dicts. so ive made that change and it works (i think) but i have a feeling that this isnt the only change that needs to be done.

so @zerebubuth can you have a look at this to see what the real fix might be :grinning: 