### PR TITLE
Batch downloading

### DIFF
--- a/joerd/command.py
+++ b/joerd/command.py
@@ -15,6 +15,10 @@ import math
 
 
 def _make_queue(j, config):
+    """
+    Makes a queue object by looking up the plugin module mentioned in the type
+    parameter of the configuration.
+    """
     typ = config['type']
     create_fn = plugin('queue', typ, 'create')
     return create_fn(j, config)
@@ -39,11 +43,17 @@ class JoerdArgumentParser(argparse.ArgumentParser):
         sys.exit(2)
 
 
-def joerd_server(global_cfg):
+def joerd_server(cfg):
+    """
+    Runs a server in an infinite loop.
+
+    This grabs jobs from the queue and processes them. Jobs which cannot be
+    processed due to an error are ignored and the next job is processed.
+    """
     logger = logging.getLogger('process')
 
-    j = Server(global_cfg)
-    queue = _make_queue(j, global_cfg.queue_config)
+    j = Server(cfg)
+    queue = _make_queue(j, cfg.queue_config)
 
     while True:
         for message in queue.receive_messages():
@@ -66,7 +76,11 @@ def joerd_server(global_cfg):
 
 def joerd_enqueue_renders(cfg):
     """
-    Sends each region in the config file to the queue for processing by workers.
+    Sends each output tile configured for the regions in the config file to
+    the queue for processing by workers.
+
+    Note that downloading to the store should have happened before this is
+    run, as the render process has no way to download files.
     """
 
     logger = logging.getLogger('enqueuer')

--- a/joerd/command.py
+++ b/joerd/command.py
@@ -1,11 +1,6 @@
 from config import make_config_from_argparse
 from osgeo import gdal
-from importlib import import_module
-from multiprocessing import Pool, Array
-import joerd.download as download
-import joerd.tmpdir as tmpdir
-from joerd.region import RegionTile
-from joerd.mkdir_p import mkdir_p
+from joerd.server import Server
 import sys
 import argparse
 import os
@@ -16,9 +11,6 @@ import time
 import traceback
 import json
 import boto3
-from contextlib2 import ExitStack, contextmanager
-import subprocess
-import ctypes
 import math
 
 
@@ -33,193 +25,6 @@ def create_command_parser(fn):
         return parser
     return create_parser_fn
 
-def _remaining_disk(path):
-    df = subprocess.Popen(['df', '-k', '-P', path], stdout=subprocess.PIPE)
-    remaining = df.communicate()[0]
-    remaining = remaining.split('\n')[1]
-    remaining = remaining.split()[3]
-    return int(remaining) * 1024
-
-@contextmanager
-def lock_array(a, **opts):
-    a.acquire(**opts)
-    try:
-        yield a
-    finally:
-        a.release()
-
-def _make_space(tmps, path):
-    #if theres nothing to do bail
-    with lock_array(_superfluous, block=True) as superfluous:
-        if len(superfluous) and not superfluous[len(superfluous) - 1]:
-            raise Exception('Need more space but nothing superfluous to delete.')
-        #assume unpacking will need at least this much space
-        needed = 0
-        for t in tmps:
-            needed += os.path.getsize(t.name)
-        #keep removing stuff until we have enough
-        remaining = _remaining_disk(path)
-        for i in range(len(superfluous)):
-            if remaining >= needed:
-                return
-            s = superfluous[i]
-            superfluous[i] = ''
-            if s:
-                try:
-                    _logger.info('Removing %s to free up space.' % s)
-                    gained = os.path.getsize(s)
-                    os.remove(s)
-                    remaining += gained
-                except:
-                    pass
-    #still not enough
-    if remaining < needed:
-        raise Exception('Not enough space left on device to continue, need at least %d more bytes.' % (needed - remaining))
-
-def _init_processes(s, l):
-    # in this case its global for each separate process
-    global _superfluous
-    _superfluous = s
-    global _logger
-    _logger = l
-
-    # make sure process will error if GDAL fails
-    gdal.UseExceptions()
-
-
-def _download(d, store):
-    logger = logging.getLogger('download')
-
-    try:
-        options = download.options(d.options()).copy()
-        options['verifier'] = d.verifier()
-
-        with ExitStack() as stack:
-            def _get(u):
-                return stack.enter_context(download.get(u, options))
-
-            tmps = [_get(url) for url in d.urls()]
-
-            while True:
-                try:
-                    d.unpack(store, *tmps)
-                    break
-                except Exception as e:
-                    #TODO: only catch out of space exception
-                    logger.error(repr(e))
-                    # disable attempt to make space for now - the code changes
-                    # make it non-functional.
-                    #_make_space(tmps, os.path.dirname(d.output_file()))
-
-        assert store.exists(d.output_file())
-
-    except:
-        raise Exception("".join(traceback.format_exception(*sys.exc_info())))
-
-
-def _render(t, store):
-    try:
-        with tmpdir.tmpdir() as d:
-            t.render(d)
-            store.upload_all(d)
-
-    except:
-        raise Exception("".join(traceback.format_exception(*sys.exc_info())))
-
-
-def _renderstar(args):
-    _render(*args)
-
-
-# ProgressLogger - logs progress towards a goal to the given logger.
-# This is useful for letting the user know that something is happening, and
-# roughly how far along it is. Progress is logged at given percentage
-# intervals or time intervals, whichever is crossed first.
-class ProgressLogger(object):
-    def __init__(self, logger, total, time_interval=10, pct_interval=5):
-        self.logger = logger
-        self.total = total
-        self.progress = 0
-        self.time_interval = time_interval
-        self.pct_interval = pct_interval
-
-        self.next_time = time.time() + self.time_interval
-        self.next_pct = self.pct_interval
-
-    def increment(self, amount):
-        self.progress += amount
-        pct = (100.0 * self.progress) / self.total
-        now = time.time()
-
-        if pct > self.next_pct or now > self.next_time:
-            self.next_pct = pct + self.pct_interval
-            self.next_time = now + self.time_interval
-            self.logger.info("Progress: %3.1f%%" % pct)
-
-
-class Joerd:
-
-    def __init__(self, cfg):
-        self.regions = cfg.regions
-        self.sources = self._sources(cfg)
-        self.outputs = self._outputs(cfg, self.sources)
-        self.num_threads = cfg.num_threads
-        self.chunksize = cfg.chunksize
-        self.store = self._store(cfg.store)
-        self.source_store = self._store(cfg.source_store)
-
-    def list_downloads(self):
-        logger = logging.getLogger('process')
-
-        # fetch index for each source, which speeds up subsequent downloads or
-        # queries about which source tiles are available.
-        for name, source in self.sources:
-            source.get_index()
-
-        # take the list of regions, which are both spatial and zoom extents,
-        # and expand them for each output, making them concrete resolutions
-        # and spatial extents enough to cover the output tiles.
-        expanded_regions = list()
-        for r in self.regions:
-            bbox = r.bbox.bounds
-            for output in self.outputs.itervalues():
-                expanded_regions.extend(output.expand_tile(bbox, r.zoom_range))
-
-        # the list of expanded regions can now be intersected with each source
-        # to find the ones which intersect, and give the set of download jobs.
-        downloads = set()
-        for tile in expanded_regions:
-            for name, source in self.sources:
-                d = source.downloads_for(tile)
-                if d:
-                    downloads.update(d)
-
-        return downloads
-
-    def _sources(self, cfg):
-        sources = []
-        for source in cfg.sources:
-            source_type = source['type']
-            module = import_module('joerd.source.%s' % source_type)
-            create_fn = getattr(module, 'create')
-            sources.append((source_type, create_fn(source)))
-        return sources
-
-    def _outputs(self, cfg, sources):
-        outputs = {}
-        for output in cfg.outputs:
-            output_type = output['type']
-            module = import_module('joerd.output.%s' % output_type)
-            create_fn = getattr(module, 'create')
-            outputs[output_type] = create_fn(cfg.regions, sources, output)
-        return outputs
-
-    def _store(self, store_cfg):
-        store_type = store_cfg['type']
-        module = import_module('joerd.store.%s' % store_type)
-        create_fn = getattr(module, 'create')
-        return create_fn(store_cfg)
-
 
 class JoerdArgumentParser(argparse.ArgumentParser):
     def error(self, message):
@@ -228,112 +33,20 @@ class JoerdArgumentParser(argparse.ArgumentParser):
         sys.exit(2)
 
 
-def _find_source_by_name(j, name):
-    for n, source in j.sources:
-        if n == name:
-            return source
-    raise Exception("Unable to find source called %r" % name)
-
-
-def _run_job_download(j, job):
-    data = job['data']
-    typ = data['type']
-    src = _find_source_by_name(j, typ)
-    rehydrated = src.rehydrate(data)
-    _download(rehydrated, j.source_store)
-
-
-class MockSource(object):
-    def __init__(self, src, vrts):
-        self.src = src
-        self.vrts = vrts
-
-    def __getattr__(self, method_name):
-        def return_vrts(self, tile):
-            return self.vrts
-
-        if method_name == 'vrts_for':
-            return return_vrts.__get__(self)
-        else:
-            return self.src.__getattribute__(method_name)
-
-
-def _download_local_vrts(d, source_store, input_vrts):
-    vrts = []
-    for rasters in input_vrts:
-        v = []
-        for r in rasters:
-            filename = os.path.join(d, r)
-            mkdir_p(os.path.dirname(filename))
-            source_store.get(r, filename)
-            assert os.path.exists(filename), "Tried to get %r from " \
-                "store and store it to %r, but that doesn't seem to " \
-                "have worked." % (r, filename)
-            v.append(filename)
-        if v:
-            vrts.append(v)
-
-    return vrts
-
-
-def _run_job_render(j, job):
-    logger = logging.getLogger('process')
-
-    data = job['data']
-    typ = data['type']
-
-    # composite operation needs to look up the sources, so we
-    # need to wrap each source in a fake source which overrides
-    # the 'vrts_for' lookup with the sources we baked into the
-    # job.
-    sources = job.get('sources')
-    assert sources, "Got tile render job with no sources! Job was: " \
-        "%r" % job
-
-    rehydrated = j.outputs[typ].rehydrate(data)
-
-    with tmpdir.tmpdir() as d:
-        mock_sources = []
-        for s in sources:
-            src = _find_source_by_name(j, s['source'])
-            vrts = _download_local_vrts(d, j.source_store, s['vrts'])
-            if vrts:
-                mock_sources.append(MockSource(src, vrts))
-
-        rehydrated.set_sources(mock_sources)
-
-        _render(rehydrated, j.store)
-
-
-def _dispatch_job(j, message_body):
-    job = json.loads(message_body)
-    job_type = job.get('job')
-
-    if job_type == 'download':
-        _run_job_download(j, job)
-
-    elif job_type == 'render':
-        _run_job_render(j, job)
-
-    else:
-        raise Exception("Don't understand job type %r from job %r, " \
-                        "ignoring." % (job_type, job))
-
-
 def joerd_server(global_cfg):
     logger = logging.getLogger('process')
 
     assert global_cfg.sqs_queue_name is not None, \
         "Could not find SQS queue name in config, but this must be configured."
 
-    j = Joerd(global_cfg)
+    j = Server(global_cfg)
     sqs = boto3.resource('sqs')
     queue = sqs.get_queue_by_name(QueueName=global_cfg.sqs_queue_name)
 
     while True:
         for message in queue.receive_messages():
             try:
-                _dispatch_job(j, message.body)
+                j.dispatch_job(message.body)
 
             except StandardError as e:
                 logger.warning("During processing of job %r, caught "
@@ -357,7 +70,7 @@ def joerd_enqueuer(cfg):
 
     logger = logging.getLogger('enqueuer')
 
-    j = Joerd(cfg)
+    j = Server(cfg)
 
     logger.info("Streaming jobs to the queue")
     sqs = boto3.resource('sqs')
@@ -417,7 +130,7 @@ def joerd_enqueue_downloads(cfg):
 
     logger = logging.getLogger('enqueuer')
 
-    j = Joerd(cfg)
+    j = Server(cfg)
     downloads = j.list_downloads()
 
     logger.info("Sending %d download jobs to the queue" % len(downloads))

--- a/joerd/composite.py
+++ b/joerd/composite.py
@@ -108,8 +108,7 @@ def compose(tile, dst_ds, logger, dst_res):
 
             # build a VRT of just the overlapping tiles, then generate
             # the output image.
-            with vrt.build([r.output_file() for r in rasters],
-                           source.srs().ExportToWkt()) as src_ds:
+            with vrt.build(rasters, source.srs().ExportToWkt()) as src_ds:
                 _mk_image(src_ds, mem_ds, _filter_type_func)
 
             # extract the output data, but only those which are not nodata,

--- a/joerd/config.py
+++ b/joerd/config.py
@@ -7,7 +7,7 @@ import copy
 
 class Configuration(object):
 
-    def __init__(self, yml, jobs_file=None):
+    def __init__(self, yml):
         self.yml = yml
         self.regions = []
         for name, settings in self._cfg('regions').iteritems():
@@ -22,7 +22,6 @@ class Configuration(object):
         self.block_size = self._cfg('cluster block_size')
         self.store = self._cfg('store')
         self.source_store = self._cfg('source_store')
-        self.jobs_file = jobs_file
 
     def copy_with_regions(self, regions):
         """
@@ -97,4 +96,4 @@ def make_config_from_argparse(config, opencfg=open):
     with opencfg(config.config) as config_fp:
         yml_data = load(config_fp.read())
         cfg = merge_cfg(cfg, yml_data)
-    return Configuration(cfg, config.jobs_file)
+    return Configuration(cfg)

--- a/joerd/config.py
+++ b/joerd/config.py
@@ -1,6 +1,5 @@
 from yaml import load
 from util import BoundingBox
-from multiprocessing import cpu_count
 from joerd.region import Region
 import copy
 
@@ -16,8 +15,6 @@ class Configuration(object):
         self.sources = self._cfg('sources')
         self.outputs = self._cfg('outputs')
         self.logconfig = self._cfg('logging config')
-        self.num_threads = self._cfg('jobs num_threads')
-        self.chunksize = self._cfg('jobs chunksize')
         self.queue_config = self._cfg('cluster queue')
         self.block_size = self._cfg('cluster block_size')
         self.store = self._cfg('store')
@@ -60,10 +57,6 @@ def default_yml_config():
         'outputs': [],
         'logging': {
             'config': None
-        },
-        'jobs': {
-            'num_threads': cpu_count(),
-            'chunksize': None,
         },
         'cluster': {
             'queue': {

--- a/joerd/config.py
+++ b/joerd/config.py
@@ -18,7 +18,7 @@ class Configuration(object):
         self.logconfig = self._cfg('logging config')
         self.num_threads = self._cfg('jobs num_threads')
         self.chunksize = self._cfg('jobs chunksize')
-        self.sqs_queue_name = self._cfg('cluster sqs_queue_name')
+        self.queue_config = self._cfg('cluster queue')
         self.block_size = self._cfg('cluster block_size')
         self.store = self._cfg('store')
         self.source_store = self._cfg('source_store')
@@ -66,7 +66,9 @@ def default_yml_config():
             'chunksize': None,
         },
         'cluster': {
-            'sqs_queue_name': None,
+            'queue': {
+                'type': 'fake',
+            },
             'block_size': 2,
         },
         'store': {

--- a/joerd/config.py
+++ b/joerd/config.py
@@ -21,6 +21,7 @@ class Configuration(object):
         self.sqs_queue_name = self._cfg('cluster sqs_queue_name')
         self.block_size = self._cfg('cluster block_size')
         self.store = self._cfg('store')
+        self.source_store = self._cfg('source_store')
         self.jobs_file = jobs_file
 
     def copy_with_regions(self, regions):
@@ -70,6 +71,10 @@ def default_yml_config():
             'block_size': 2,
         },
         'store': {
+            'type': 'file',
+            'base_dir': '.',
+        },
+        'source_store': {
             'type': 'file',
             'base_dir': '.',
         },

--- a/joerd/config.py
+++ b/joerd/config.py
@@ -7,7 +7,7 @@ import copy
 
 class Configuration(object):
 
-    def __init__(self, yml):
+    def __init__(self, yml, jobs_file=None):
         self.yml = yml
         self.regions = []
         for name, settings in self._cfg('regions').iteritems():
@@ -21,6 +21,7 @@ class Configuration(object):
         self.sqs_queue_name = self._cfg('cluster sqs_queue_name')
         self.block_size = self._cfg('cluster block_size')
         self.store = self._cfg('store')
+        self.jobs_file = jobs_file
 
     def copy_with_regions(self, regions):
         """
@@ -85,10 +86,10 @@ def merge_cfg(dest, source):
     return dest
 
 
-def make_config_from_argparse(config_path, opencfg=open):
+def make_config_from_argparse(config, opencfg=open):
     # opencfg for testing
     cfg = default_yml_config()
-    with opencfg(config_path) as config_fp:
+    with opencfg(config.config) as config_fp:
         yml_data = load(config_fp.read())
         cfg = merge_cfg(cfg, yml_data)
-    return Configuration(cfg)
+    return Configuration(cfg, config.jobs_file)

--- a/joerd/mkdir_p.py
+++ b/joerd/mkdir_p.py
@@ -1,0 +1,21 @@
+import os
+import os.path
+import errno
+
+
+def mkdir_p(dirname):
+    """
+    A function which makes a directory and doesn't throw an exception if it
+    already exists.
+    """
+
+    if os.path.isdir(dirname):
+        return
+
+    try:
+        os.makedirs(dirname)
+    except OSError as e:
+        if exc.errno == errno.EEXIST and os.path.isdir(dirname):
+            pass
+        else:
+            raise e

--- a/joerd/output/normal.py
+++ b/joerd/output/normal.py
@@ -108,13 +108,8 @@ class NormalTile(object):
                      % (self.z, [type(s).__name__ for s in sources]))
         self.sources = sources
 
-    @classmethod
-    def from_json(cls, datadict):
-        return cls(datadict.get('output_dir'),
-                   datadict.get('_latlon_bbox'),
-                   datadict.get('z'),
-                   datadict.get('x'),
-                   datadict.get('y'))
+    def freeze_dry(self):
+        return dict(type='normal', z=self.z, x=self.x, y=self.y)
 
     def latlon_bbox(self):
         return self._latlon_bbox
@@ -373,6 +368,17 @@ class Normal:
         tx = int(extent * ((x / MERCATOR_WORLD_SIZE) + 0.5))
         ty = int(extent * (0.5 - (y / MERCATOR_WORLD_SIZE)))
         return (tx, ty)
+
+    def rehydrate(self, data):
+        typ = data.get('type')
+        assert typ == 'normal', "Unable to rehydrate tile of type %r in " \
+            "normal output. Job was: %r" % (typ, data)
+
+        z = data['z']
+        x = data['x']
+        y = data['y']
+        bbox = self.latlon_bbox(z, x, y)
+        return NormalTile(self.output_dir, bbox, z, x, y)
 
 
 def create(regions, sources, options):

--- a/joerd/output/normal.py
+++ b/joerd/output/normal.py
@@ -95,10 +95,11 @@ def _merc_bbox(z, x, y):
 
 class NormalTile(object):
     def __init__(self, parent, z, x, y):
-        self.parent = parent
+        self.output_dir = parent.output_dir
         self.z = z
         self.x = x
         self.y = y
+        self._latlon_bbox = parent.latlon_bbox(self.z, self.x, self.y)
 
     def set_sources(self, sources):
         logger = logging.getLogger('normal')
@@ -107,7 +108,7 @@ class NormalTile(object):
         self.sources = sources
 
     def latlon_bbox(self):
-        return self.parent.latlon_bbox(self.z, self.x, self.y)
+        return self._latlon_bbox
 
     def max_resolution(self):
         bbox = self.latlon_bbox().bounds
@@ -119,7 +120,7 @@ class NormalTile(object):
 
         bbox = _merc_bbox(self.z, self.x, self.y)
 
-        mid_dir = os.path.join(tmp_dir, self.parent.output_dir,
+        mid_dir = os.path.join(tmp_dir, self.output_dir,
                                str(self.z), str(self.x))
         if not os.path.isdir(mid_dir):
             try:
@@ -131,7 +132,7 @@ class NormalTile(object):
                     raise
 
         tile = _tile_name(self.z, self.x, self.y)
-        tile_file = os.path.join(tmp_dir, self.parent.output_dir,
+        tile_file = os.path.join(tmp_dir, self.output_dir,
                                  tile + ".png")
         logger.debug("Generating tile %r..." % tile)
 
@@ -187,7 +188,7 @@ class NormalTile(object):
 
         # figure out what the approximate scale of the output image is in
         # lat/lon coordinates. this is used to select the appropriate filter.
-        ll_bbox = self.parent.latlon_bbox(self.z, self.x, self.y)
+        ll_bbox = self._latlon_bbox
         ll_x_res = float(ll_bbox.bounds[2] - ll_bbox.bounds[0]) / dst_x_size
         ll_y_res = float(ll_bbox.bounds[3] - ll_bbox.bounds[1]) / dst_y_size
 

--- a/joerd/output/skadi.py
+++ b/joerd/output/skadi.py
@@ -52,7 +52,7 @@ def _parse_tile(tile_name):
 
 class SkadiTile(object):
     def __init__(self, parent, x, y):
-        self.parent = parent
+        self.output_dir = parent.output_dir
         self.x = x
         self.y = y
 
@@ -73,7 +73,7 @@ class SkadiTile(object):
 
         bbox = _bbox(self.x, self.y)
 
-        mid_dir = os.path.join(tmp_dir, self.parent.output_dir,
+        mid_dir = os.path.join(tmp_dir, self.output_dir,
                                ("N" if self.y >= 90 else "S") +
                                ("%02d" % abs(self.y - 90)))
         if not os.path.isdir(mid_dir):

--- a/joerd/output/skadi.py
+++ b/joerd/output/skadi.py
@@ -64,11 +64,8 @@ class SkadiTile(object):
                      % ((self.x, self.y), [type(s).__name__ for s in sources]))
         self.sources = sources
 
-    @classmethod
-    def from_json(cls, datadict):
-        return cls(datadict.get('output_dir'),
-                   datadict.get('x'),
-                   datadict.get('y'))
+    def freeze_dry(self):
+        return dict(type='skadi', x=self.x, y=self.y)
 
     def latlon_bbox(self):
         return _bbox(self.x, self.y)
@@ -180,6 +177,15 @@ class Skadi:
 
         logger.info("Generated %d tile jobs." % len(tiles))
         return tiles
+
+    def rehydrate(self, data):
+        typ = data.get('type')
+        assert typ == 'skadi', "Unable to rehydrate tile of type %r in " \
+            "skadi output. Job was: %r" % (typ, data)
+
+        x = data['x']
+        y = data['y']
+        return SkadiTile(self.output_dir, x, y)
 
 
 def create(regions, sources, options):

--- a/joerd/output/terrarium.py
+++ b/joerd/output/terrarium.py
@@ -1,4 +1,5 @@
 from joerd.util import BoundingBox
+from joerd.region import RegionTile
 from tempfile import NamedTemporaryFile as Tmp
 from osgeo import osr, gdal
 import re
@@ -257,6 +258,20 @@ class Terrarium:
     def __setstate__(self, d):
         self.__dict__.update(d)
         self._setup_transforms()
+
+    def expand_tile(self, bbox, zoom_range):
+        tiles = []
+
+        for z in range(*zoom_range):
+            lx, ly = self.lonlat_to_xy(z, bbox[0], bbox[1])
+            ux, uy = self.lonlat_to_xy(z, bbox[2], bbox[3])
+            ll = self.latlon_bbox(z, lx, ly).bounds
+            ur = self.latlon_bbox(z, ux, uy).bounds
+            res = max((ll[2] - ll[0]) / 256.0,
+                      (ur[2] - ur[0]) / 256.0)
+            tiles.append(RegionTile((ll[0], ll[1], ur[2], ur[3]), res))
+
+        return tiles
 
     def generate_tiles(self):
         logger = logging.getLogger('terrarium')

--- a/joerd/output/terrarium.py
+++ b/joerd/output/terrarium.py
@@ -85,6 +85,9 @@ class TerrariumTile(object):
                      % (self.z, [type(s).__name__ for s in sources]))
         self.sources = sources
 
+    def freeze_dry(self):
+        return dict(type='terrarium', z=self.z, x=self.x, y=self.y)
+
     def latlon_bbox(self):
         return self._latlon_bbox
 
@@ -303,6 +306,15 @@ class Terrarium:
         ty = int(extent * (0.5 - (y / MERCATOR_WORLD_SIZE)))
         return (tx, ty)
 
+    def rehydrate(self, data):
+        typ = data.get('type')
+        assert typ == 'terrarium', "Unable to rehydrate tile of type %r in " \
+            "terrarium output. Job was: %r" % (typ, data)
+
+        z = data['z']
+        x = data['x']
+        y = data['y']
+        return TerrariumTile(self, z, x, y)
 
 def create(regions, sources, options):
     return Terrarium(regions, sources, options)

--- a/joerd/output/terrarium.py
+++ b/joerd/output/terrarium.py
@@ -70,10 +70,13 @@ def _merc_bbox(z, x, y):
 
 class TerrariumTile(object):
     def __init__(self, parent, z, x, y):
-        self.parent = parent
+        self.output_dir = parent.output_dir
+        self.enable_png = parent.enable_png
+        self.enable_tif = parent.enable_tif
         self.z = z
         self.x = x
         self.y = y
+        self._latlon_bbox = parent.latlon_bbox(self.z, self.x, self.y)
 
     def set_sources(self, sources):
         logger = logging.getLogger('terrarium')
@@ -82,7 +85,7 @@ class TerrariumTile(object):
         self.sources = sources
 
     def latlon_bbox(self):
-        return self.parent.latlon_bbox(self.z, self.x, self.y)
+        return self._latlon_bbox
 
     def max_resolution(self):
         bbox = self.latlon_bbox().bounds
@@ -94,7 +97,7 @@ class TerrariumTile(object):
 
         bbox = _merc_bbox(self.z, self.x, self.y)
 
-        mid_dir = os.path.join(tmp_dir, self.parent.output_dir,
+        mid_dir = os.path.join(tmp_dir, self.output_dir,
                                str(self.z), str(self.x))
         if not os.path.isdir(mid_dir):
             try:
@@ -128,13 +131,13 @@ class TerrariumTile(object):
 
         # figure out what the approximate scale of the output image is in
         # lat/lon coordinates. this is used to select the appropriate filter.
-        ll_bbox = self.parent.latlon_bbox(self.z, self.x, self.y)
+        ll_bbox = self.latlon_bbox()
         ll_x_res = float(ll_bbox.bounds[2] - ll_bbox.bounds[0]) / dst_x_size
         ll_y_res = float(ll_bbox.bounds[3] - ll_bbox.bounds[1]) / dst_y_size
 
         composite.compose(self, dst_ds, logger, min(ll_x_res, ll_y_res))
 
-        if self.parent.enable_png:
+        if self.enable_png:
             # we want the output to be 3-channels R, G, B with:
             #   uheight = height + 32768.0
             #   R = int(height) / 256
@@ -166,7 +169,7 @@ class TerrariumTile(object):
             res = mem_ds.GetRasterBand(3).WriteArray(b)
             assert res == gdal.CPLE_None
 
-            png_file = os.path.join(tmp_dir, self.parent.output_dir,
+            png_file = os.path.join(tmp_dir, self.output_dir,
                                     tile + ".png")
             png_drv = gdal.GetDriverByName("PNG")
             png_ds = png_drv.CreateCopy(png_file, mem_ds)
@@ -179,12 +182,12 @@ class TerrariumTile(object):
 
             assert os.path.isfile(png_file)
 
-        if self.parent.enable_tif:
+        if self.enable_tif:
             # TIFF compresses best if we stick to integer pixels, using LZW
             # and the "2" type predictor. we might be able to keep some bits
             # of precision with float32 and DISCARD_LSB, but that's only
             # available in GDAL >= 2.0
-            tile_file = os.path.join(tmp_dir, self.parent.output_dir,
+            tile_file = os.path.join(tmp_dir, self.output_dir,
                                      tile + ".tif")
             outfile = tile_file
             tif_drv = gdal.GetDriverByName("GTiff")

--- a/joerd/plugin.py
+++ b/joerd/plugin.py
@@ -1,0 +1,6 @@
+from importlib import import_module
+
+def plugin(typ, name, func_name):
+    module = import_module('joerd.%s.%s' % (typ, name))
+    fn = getattr(module, func_name)
+    return fn

--- a/joerd/plugin.py
+++ b/joerd/plugin.py
@@ -1,6 +1,18 @@
 from importlib import import_module
 
 def plugin(typ, name, func_name):
+    """
+    Generic pattern for plugins which conform to the same interface. These
+    abstract away the details of exactly how something is performed. There are
+    several types of these in Joerd:
+
+      * Sources, which know about data sources and how to download them.
+      * Outputs, which know about output formats and know how to render
+        them.
+      * Stores, which know about storing files.
+      * Queues, which know about communicating jobs.
+    """
+
     module = import_module('joerd.%s.%s' % (typ, name))
     fn = getattr(module, func_name)
     return fn

--- a/joerd/queue/fake.py
+++ b/joerd/queue/fake.py
@@ -1,0 +1,19 @@
+class Queue(object):
+    def __init__(self, server):
+        self.server = server
+
+    def batch_size(self):
+        return 1
+
+    def send_messages(self, batch):
+        for msg in batch:
+            self.server.dispatch_job(msg)
+
+    def receive_messages(self):
+        # fake queue doesn't actually hold any messages, so this is really
+        # an error.
+        raise Exception("Fake queue doesn't hold any messages.")
+
+
+def create(j, cfg):
+    return Queue(j)

--- a/joerd/queue/fake.py
+++ b/joerd/queue/fake.py
@@ -1,4 +1,11 @@
 class Queue(object):
+    """
+    A fake queue, which doesn't store or communicate any messages at all, but
+    calls the server to have them processed immediately.
+
+    This is useful for testing and running locally.
+    """
+
     def __init__(self, server):
         self.server = server
 

--- a/joerd/queue/sqs.py
+++ b/joerd/queue/sqs.py
@@ -3,6 +3,11 @@ import json
 
 
 class Message(object):
+    """
+    A wrapper around the SQS message, basically to unpack the JSON body and
+    hold a message handle so that delete can be called on success.
+    """
+
     def __init__(msg):
         self.msg = msg
         self.body = json.loads(self.msg.body)
@@ -12,6 +17,12 @@ class Message(object):
 
 
 class Queue(object):
+    """
+    A queue which uses SQS behind the scenes to send and receive messages.
+
+    This encodes each job as a JSON payload in the native SQS message type.
+    """
+
     def __init__(config):
         queue_name = config.get('queue_name')
         assert queue_name is not None, \

--- a/joerd/queue/sqs.py
+++ b/joerd/queue/sqs.py
@@ -1,0 +1,45 @@
+import boto3
+import json
+
+
+class Message(object):
+    def __init__(msg):
+        self.msg = msg
+        self.body = json.loads(self.msg.body)
+
+    def delete(self):
+        self.msg.delete()
+
+
+class Queue(object):
+    def __init__(config):
+        queue_name = config.get('queue_name')
+        assert queue_name is not None, \
+            "Could not find SQS queue name in config, but this must be " \
+            "configured when using SQS queues."
+
+        self.sqs = boto3.resource('sqs')
+        self.queue = self.sqs.get_queue_by_name(QueueName=queue_name)
+        self.idx = 0
+
+    def batch_size(self):
+        return 10
+
+    def send_messages(self, batch):
+        entries = []
+        for job in batch:
+            entries.append(dict(Id=str(self.idx),
+                                MessageBody=json.dumps(job)))
+            self.idx += 1
+
+        result = self.queue.send_messages(Entries=entries)
+        if 'Failed' in result and result['Failed']:
+            raise Exception("Failed to enqueue: %r" % result['Failed'])
+
+    def receive_messages(self):
+        for msg in self.queue.receive_messages():
+            yield SQSMessage(msg)
+
+
+def create(j, cfg):
+    return Queue(cfg)

--- a/joerd/region.py
+++ b/joerd/region.py
@@ -1,3 +1,5 @@
+from joerd.util import BoundingBox
+
 class Region(object):
     """
     Represents a selection of space and a range of scales at which to render.
@@ -19,3 +21,15 @@ class Region(object):
         return self.bbox.intersects(bbox) and \
             zoom >= self.zoom_range[0] and \
             zoom < self.zoom_range[1]
+
+
+class RegionTile(object):
+    def __init__(self, bbox, max_res):
+        self.bbox = bbox
+        self.max_res = max_res
+
+    def latlon_bbox(self):
+        return BoundingBox(*self.bbox)
+
+    def max_resolution(self):
+        return self.max_res

--- a/joerd/server.py
+++ b/joerd/server.py
@@ -113,8 +113,6 @@ class Server:
         self.regions = cfg.regions
         self.sources = self._sources(cfg)
         self.outputs = self._outputs(cfg, self.sources)
-        self.num_threads = cfg.num_threads
-        self.chunksize = cfg.chunksize
         self.store = self._store(cfg.store)
         self.source_store = self._store(cfg.source_store)
 

--- a/joerd/server.py
+++ b/joerd/server.py
@@ -1,0 +1,205 @@
+from joerd.mkdir_p import mkdir_p
+import joerd.tmpdir as tmpdir
+import joerd.download as download
+from importlib import import_module
+from contextlib2 import ExitStack, contextmanager
+import logging
+import traceback
+import json
+import os.path
+import sys
+
+
+def _download(d, store):
+    logger = logging.getLogger('download')
+
+    try:
+        options = download.options(d.options()).copy()
+        options['verifier'] = d.verifier()
+
+        with ExitStack() as stack:
+            def _get(u):
+                return stack.enter_context(download.get(u, options))
+
+            tmps = [_get(url) for url in d.urls()]
+
+            while True:
+                try:
+                    d.unpack(store, *tmps)
+                    break
+                except Exception as e:
+                    logger.error(repr(e))
+
+        assert store.exists(d.output_file())
+
+    except:
+        raise Exception("".join(traceback.format_exception(*sys.exc_info())))
+
+
+def _download_local_vrts(d, source_store, input_vrts):
+    vrts = []
+    for rasters in input_vrts:
+        v = []
+        for r in rasters:
+            filename = os.path.join(d, r)
+            mkdir_p(os.path.dirname(filename))
+            source_store.get(r, filename)
+            assert os.path.exists(filename), "Tried to get %r from " \
+                "store and store it to %r, but that doesn't seem to " \
+                "have worked." % (r, filename)
+            v.append(filename)
+        if v:
+            vrts.append(v)
+
+    return vrts
+
+
+def _render(t, store):
+    try:
+        with tmpdir.tmpdir() as d:
+            t.render(d)
+            store.upload_all(d)
+
+    except:
+        raise Exception("".join(traceback.format_exception(*sys.exc_info())))
+
+
+class MockSource(object):
+    def __init__(self, src, vrts):
+        self.src = src
+        self.vrts = vrts
+
+    def __getattr__(self, method_name):
+        def return_vrts(self, tile):
+            return self.vrts
+
+        if method_name == 'vrts_for':
+            return return_vrts.__get__(self)
+        else:
+            return self.src.__getattribute__(method_name)
+
+
+class Server:
+
+    def __init__(self, cfg):
+        self.regions = cfg.regions
+        self.sources = self._sources(cfg)
+        self.outputs = self._outputs(cfg, self.sources)
+        self.num_threads = cfg.num_threads
+        self.chunksize = cfg.chunksize
+        self.store = self._store(cfg.store)
+        self.source_store = self._store(cfg.source_store)
+
+    def list_downloads(self):
+        logger = logging.getLogger('process')
+
+        # fetch index for each source, which speeds up subsequent downloads or
+        # queries about which source tiles are available.
+        for name, source in self.sources:
+            source.get_index()
+
+        # take the list of regions, which are both spatial and zoom extents,
+        # and expand them for each output, making them concrete resolutions
+        # and spatial extents enough to cover the output tiles.
+        expanded_regions = list()
+        for r in self.regions:
+            bbox = r.bbox.bounds
+            for output in self.outputs.itervalues():
+                expanded_regions.extend(output.expand_tile(bbox, r.zoom_range))
+
+        # the list of expanded regions can now be intersected with each source
+        # to find the ones which intersect, and give the set of download jobs.
+        downloads = set()
+        for tile in expanded_regions:
+            for name, source in self.sources:
+                d = source.downloads_for(tile)
+                if d:
+                    downloads.update(d)
+
+        return downloads
+
+    def _sources(self, cfg):
+        sources = []
+        for source in cfg.sources:
+            source_type = source['type']
+            module = import_module('joerd.source.%s' % source_type)
+            create_fn = getattr(module, 'create')
+            sources.append((source_type, create_fn(source)))
+        return sources
+
+    def _outputs(self, cfg, sources):
+        outputs = {}
+        for output in cfg.outputs:
+            output_type = output['type']
+            module = import_module('joerd.output.%s' % output_type)
+            create_fn = getattr(module, 'create')
+            outputs[output_type] = create_fn(cfg.regions, sources, output)
+        return outputs
+
+    def _store(self, store_cfg):
+        store_type = store_cfg['type']
+        module = import_module('joerd.store.%s' % store_type)
+        create_fn = getattr(module, 'create')
+        return create_fn(store_cfg)
+
+    def _find_source_by_name(self, name):
+        for n, source in self.sources:
+            if n == name:
+                return source
+        raise Exception("Unable to find source called %r" % name)
+
+    def _download(self, rehydrated):
+        _download(rehydrated, self.source_store)
+
+    def _render(self, rehydrated, sources):
+        with tmpdir.tmpdir() as d:
+            mock_sources = []
+            for s in sources:
+                src = self._find_source_by_name(s['source'])
+                vrts = _download_local_vrts(d, self.source_store, s['vrts'])
+            if vrts:
+                mock_sources.append(MockSource(src, vrts))
+
+            rehydrated.set_sources(mock_sources)
+
+            _render(rehydrated, self.store)
+
+    def _run_job_download(self, job):
+        data = job['data']
+        typ = data['type']
+        src = self._find_source_by_name(typ)
+        rehydrated = src.rehydrate(data)
+        self._download(rehydrated)
+
+    def _run_job_render(self, job):
+        logger = logging.getLogger('process')
+
+        data = job['data']
+        typ = data['type']
+
+        # composite operation needs to look up the sources, so we
+        # need to wrap each source in a fake source which overrides
+        # the 'vrts_for' lookup with the sources we baked into the
+        # job.
+        sources = job.get('sources')
+        assert sources, "Got tile render job with no sources! Job was: " \
+            "%r" % job
+
+        rehydrated = self.outputs[typ].rehydrate(data)
+        self._render(rehydrated, sources)
+
+    def dispatch_job(self, message_body):
+        logger = logging.getLogger('process')
+
+        job = json.loads(message_body)
+        job_type = job.get('job')
+
+        if job_type == 'download':
+            self._run_job_download(job)
+
+        elif job_type == 'render':
+            self._run_job_render(job)
+
+        else:
+            raise Exception("Don't understand job type %r from job %r, " \
+                            "ignoring." % (job_type, job))

--- a/joerd/server.py
+++ b/joerd/server.py
@@ -10,6 +10,10 @@ import sys
 
 
 def _download(d, store):
+    """
+    Download a source file from the internet and store it in the given store.
+    """
+
     logger = logging.getLogger('download')
 
     try:
@@ -36,6 +40,15 @@ def _download(d, store):
 
 
 def _download_local_vrts(d, source_store, input_vrts):
+    """
+    The input VRTs are stored in the source_store, but GDAL doesn't know about
+    any store other than the filesystem. This function downloads all the files
+    referenced in the VRTs to a local, temporary directory and rewrites the
+    vrts to include the local paths instead of the remote ones.
+
+    It returns the list of list of rewritten VRT paths.
+    """
+
     vrts = []
     for rasters in input_vrts:
         v = []
@@ -54,6 +67,11 @@ def _download_local_vrts(d, source_store, input_vrts):
 
 
 def _render(t, store):
+    """
+    Renders a tile, sending output to a temporary directory and puts the
+    result(s) in the store.
+    """
+
     try:
         with tmpdir.tmpdir() as d:
             t.render(d)
@@ -64,6 +82,12 @@ def _render(t, store):
 
 
 class MockSource(object):
+    """
+    Used to wrap a source and override its `vrts_for` method so that VRTs which
+    have been downloaded from a source store to the local filesystem can be
+    used.
+    """
+
     def __init__(self, src, vrts):
         self.src = src
         self.vrts = vrts
@@ -79,6 +103,11 @@ class MockSource(object):
 
 
 class Server:
+    """
+    Joerd "server" or worker class. It can list the downloads required for a
+    configured region or run a job. Jobs can be either downloads of a single
+    source file or renders of a single output tile.
+    """
 
     def __init__(self, cfg):
         self.regions = cfg.regions

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -2,6 +2,7 @@ from joerd.util import BoundingBox
 import joerd.download as download
 import joerd.check as check
 import joerd.srs as srs
+from joerd.mkdir_p import mkdir_p
 from shutil import copyfile
 import os.path
 import os
@@ -74,9 +75,13 @@ class ETOPO1(object):
     def verifier(self):
         return check.is_zip
 
-    def unpack(self, tmp):
-        with zipfile.ZipFile(tmp.name, 'r') as zfile:
-            zfile.extract(self.target_name, self.base_dir)
+    def unpack(self, store, tmp):
+        with store.upload_dir() as target:
+            target_dir = os.path.join(target, self.base_dir)
+            mkdir_p(target_dir)
+
+            with zipfile.ZipFile(tmp.name, 'r') as zfile:
+                zfile.extract(self.target_name, target_dir)
 
     def srs(self):
         return srs.wgs84()

--- a/joerd/source/etopo1.py
+++ b/joerd/source/etopo1.py
@@ -22,7 +22,7 @@ class ETOPO1(object):
     def __init__(self, options={}):
         self.base_dir = options.get('base_dir', 'etopo1')
         self.etopo1_url = options['url']
-        self.download_options = download.options(options)
+        self.download_options = options
         self.target_name = 'ETOPO1_Bed_g_geotiff.tif'
 
     def get_index(self):
@@ -34,6 +34,15 @@ class ETOPO1(object):
     def existing_files(self):
         if os.path.exists(self.output_file()):
             yield self.output_file()
+
+    def freeze_dry(self):
+        # there's only one ETOPO1 tile
+        return dict(type='etopo1')
+
+    def rehydrate(self, data):
+        assert data.get('type') == 'etopo1', \
+            "Unable to rehydrate %r from ETOPO1." % data
+        return self
 
     def downloads_for(self, tile):
         # There's just one thing to download, and it's this single world

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -20,7 +20,9 @@ from osgeo import gdal
 
 class GMTEDTile(object):
     def __init__(self, parent, x, y):
-        self.parent = parent
+        self.url = parent.url
+        self.download_options = parent.download_options
+        self.base_dir = parent.base_dir
         self.x = x
         self.y = y
 
@@ -48,17 +50,17 @@ class GMTEDTile(object):
         dir = "%s%03d" % ("E" if self.x >= 0 else "W", abs(self.x))
         res = self._res()
         dname = "/%(res)sdarcsec/mea/%(dir)s/" % dict(res=res, dir=dir)
-        return [self.parent.url + dname + self._file_name()]
+        return [self.url + dname + self._file_name()]
 
     def verifier(self):
         return check.is_gdal
 
     def options(self):
-        return self.parent.download_options
+        return self.download_options
 
     def output_file(self):
         fname = self._file_name()
-        return os.path.join(self.parent.base_dir, fname)
+        return os.path.join(self.base_dir, fname)
 
     def unpack(self, tmp):
         mask.negative(tmp.name, "GTiff", self.output_file())

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -65,6 +65,9 @@ class GMTEDTile(object):
     def unpack(self, tmp):
         mask.negative(tmp.name, "GTiff", self.output_file())
 
+    def freeze_dry(self):
+        return dict(type='gmted', x=self.x, y=self.y)
+
 
 class GMTED(object):
 
@@ -74,7 +77,7 @@ class GMTED(object):
         self.url = options['url']
         self.xs = options['xs']
         self.ys = options['ys']
-        self.download_options = download.options(options)
+        self.download_options = options
 
     def get_index(self):
         # GMTED is a static set of files - there's no need for an index, but we
@@ -87,6 +90,11 @@ class GMTED(object):
             for f in  files:
                 if f.endswith('tif'):
                     yield os.path.join(base, f)
+
+    def rehydrate(self, data):
+        assert data.get('type') == 'gmted', \
+            "Unable to rehydrate %r from GMTED." % data
+        return GMTEDTile(self, data['x'], data['y'])
 
     def downloads_for(self, tile):
         tiles = set()

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -4,7 +4,6 @@ import joerd.check as check
 import joerd.srs as srs
 import joerd.mask as mask
 from joerd.mkdir_p import mkdir_p
-from multiprocessing import Pool
 from shutil import copyfileobj
 import os.path
 import os

--- a/joerd/source/gmted.py
+++ b/joerd/source/gmted.py
@@ -3,6 +3,7 @@ import joerd.download as download
 import joerd.check as check
 import joerd.srs as srs
 import joerd.mask as mask
+from joerd.mkdir_p import mkdir_p
 from multiprocessing import Pool
 from shutil import copyfileobj
 import os.path
@@ -62,8 +63,11 @@ class GMTEDTile(object):
         fname = self._file_name()
         return os.path.join(self.base_dir, fname)
 
-    def unpack(self, tmp):
-        mask.negative(tmp.name, "GTiff", self.output_file())
+    def unpack(self, store, tmp):
+        with store.upload_dir() as target:
+            mkdir_p(os.path.join(target, self.base_dir))
+            output_file = os.path.join(target, self.output_file())
+            mask.negative(tmp.name, "GTiff", output_file)
 
     def freeze_dry(self):
         return dict(type='gmted', x=self.x, y=self.y)

--- a/joerd/source/ned.py
+++ b/joerd/source/ned.py
@@ -35,6 +35,9 @@ class NED(object):
     def srs(self):
         return self.base.srs()
 
+    def rehydrate(self, tile):
+        return self.base.rehydrate(tile)
+
 
 def create(options):
     return NED(options)

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -6,7 +6,6 @@ import joerd.index as index
 import joerd.mask as mask
 import joerd.tmpdir as tmpdir
 from joerd.mkdir_p import mkdir_p
-from multiprocessing import Pool
 from contextlib import closing
 from shutil import copyfile
 from ftplib import FTP

--- a/joerd/source/ned_base.py
+++ b/joerd/source/ned_base.py
@@ -31,7 +31,11 @@ from itertools import groupby
 
 class NEDTile(object):
     def __init__(self, parent, state_code, region_name, year, bbox):
-        self.parent = parent
+        self.ftp_server = parent.ftp_server
+        self.base_path = parent.base_path
+        self.download_options = parent.download_options
+        self.base_dir = parent.base_dir
+        self.is_topobathy = parent.is_topobathy
         self.state_code = state_code
         self.region_name = region_name
         self.year = int(year)
@@ -48,32 +52,32 @@ class NEDTile(object):
         return hash(self.__key())
 
     def urls(self):
-        return ['ftp://%s/%s/%s' % (self.parent.ftp_server,
-                                    self.parent.base_path,
+        return ['ftp://%s/%s/%s' % (self.ftp_server,
+                                    self.base_path,
                                     self.zip_name())]
 
     def verifier(self):
         return check.is_zip
 
     def options(self):
-        return self.parent.download_options
+        return self.download_options
 
     def output_file(self):
-        return os.path.join(self.parent.base_dir, self.img_name())
+        return os.path.join(self.base_dir, self.img_name())
 
     def unpack(self, tmp):
         img = self.img_name()
 
-        if self.parent.is_topobathy:
+        if self.is_topobathy:
             with zipfile.ZipFile(tmp.name, 'r') as zfile:
-                zfile.extract(img, self.parent.base_dir)
-                zfile.extract(img + ".aux.xml", self.parent.base_dir)
+                zfile.extract(img, self.base_dir)
+                zfile.extract(img + ".aux.xml", self.base_dir)
 
         else:
             with tmpdir.tmpdir() as d:
                 with zipfile.ZipFile(tmp.name, 'r') as zfile:
                     zfile.extract(img, d)
-                    zfile.extract(img + ".aux.xml", self.parent.base_dir)
+                    zfile.extract(img + ".aux.xml", self.base_dir)
 
                 mask.negative(os.path.join(d, img),
                               "HFA", self.output_file())

--- a/joerd/source/ned_topobathy.py
+++ b/joerd/source/ned_topobathy.py
@@ -35,6 +35,9 @@ class NEDTopobathy(object):
     def srs(self):
         return self.base.srs()
 
+    def rehydrate(self, tile):
+        return self.base.rehydrate(tile)
+
 
 def create(options):
     return NEDTopobathy(options)

--- a/joerd/store/file.py
+++ b/joerd/store/file.py
@@ -1,6 +1,8 @@
 from distutils.dir_util import copy_tree
+from shutil import copyfile
 from contextlib2 import contextmanager
 from joerd.tmpdir import tmpdir
+import os.path
 
 # Stores files in a directory (defaults to the current directory)
 class FileStore(object):
@@ -18,6 +20,10 @@ class FileStore(object):
 
     def exists(self, filename):
         return os.path.exists(os.path.join(self.base_dir, filename))
+
+    def get(self, source, dest):
+        copyfile(os.path.join(self.base_dir, source), dest)
+
 
 def create(cfg):
     return FileStore(cfg)

--- a/joerd/store/file.py
+++ b/joerd/store/file.py
@@ -1,4 +1,6 @@
 from distutils.dir_util import copy_tree
+from contextlib2 import contextmanager
+from joerd.tmpdir import tmpdir
 
 # Stores files in a directory (defaults to the current directory)
 class FileStore(object):
@@ -8,6 +10,14 @@ class FileStore(object):
     def upload_all(self, d):
         copy_tree(d, self.base_dir)
 
+    @contextmanager
+    def upload_dir(self):
+        with tmpdir() as t:
+            yield t
+            self.upload_all(t)
+
+    def exists(self, filename):
+        return os.path.exists(os.path.join(self.base_dir, filename))
 
 def create(cfg):
     return FileStore(cfg)

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -106,5 +106,11 @@ class S3Store(object):
 
         return exists
 
+    def get(source, dest):
+        bucket = self._get_bucket()
+        obj = bucket.Object(filename)
+        obj.download_file(dest)
+
+
 def create(cfg):
     return S3Store(cfg)

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -2,6 +2,8 @@ import boto3
 from boto3.s3.transfer import TransferConfig
 from os import walk
 import os.path
+from contextlib2 import contextmanager
+from joerd.tmpdir import tmpdir
 
 # extension to mime type mappings to help with serving the S3 bucket as
 # a web site. if we add the content-type header on upload, then S3 will
@@ -79,6 +81,30 @@ class S3Store(object):
                                        Config=transfer_config,
                                        ExtraArgs=extra_args)
 
+    @contextmanager
+    def upload_dir(self):
+        with tmpdir() as t:
+            yield t
+            self.upload_all(t)
+
+    def exists(self, filename):
+        bucket = self._get_bucket()
+        exists = False
+        try:
+            obj = bucket.Object(filename)
+            obj.load()
+        except ClientError as e:
+            code = e.response['Error']['Code']
+            # 403 is returned instead of 404 when the bucket doesn't allow
+            # LIST operations, so treat that as missing as well.
+            if code == "404" or code == "403":
+                exists = False
+            else:
+                raise e
+        else:
+            exists = True
+
+        return exists
 
 def create(cfg):
     return S3Store(cfg)

--- a/joerd/vrt.py
+++ b/joerd/vrt.py
@@ -3,11 +3,18 @@ from contextlib2 import contextmanager, closing
 import subprocess
 import tempfile
 import logging
+import os.path
 
 
 @contextmanager
 def build(files, srs):
     with closing(tempfile.NamedTemporaryFile(suffix='.vrt')) as vrt:
+        # ensure files are actually present before trying to make a VRT from
+        # them.
+        for f in files:
+            assert os.path.exists(f), "Trying to build a VRT including file " \
+                "%r, but it does not seem to exist." % f
+
         args = ["gdalbuildvrt", "-q", "-a_srs", srs, vrt.name ] + files
         status = subprocess.call(args)
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -53,7 +53,7 @@ def make_regions(x, y, stride, sub_block_size):
                     left=(x+ix*sub_block_width+epsilon),
                     bottom=(y+iy*sub_block_width+epsilon),
                     right=(x+(ix+1)*sub_block_width-epsilon),
-                    top=(y+(iy*1)*sub_block_width-epsilon)),
+                    top=(y+(iy+1)*sub_block_width-epsilon)),
                 zoom_range=[14,16]))
 
     return regions

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -6,6 +6,7 @@ from shapely.geometry import box
 import pyqtree
 import argparse
 import math
+import json
 
 
 # convert OGR readable format to WKT representation
@@ -86,8 +87,9 @@ if __name__ == '__main__':
 
     parser.add_argument("input-file", help="Config YAML file to read as "
                         "input. Its 'regions' section will be replaced.")
-    parser.add_argument("output-file", help="Config YAML to write, with "
-                        "replaced 'regions'.")
+    parser.add_argument("output-file", help="Config jobs list to write. "
+                        "This is a file with one job per line, each job is "
+                        "a serialised JSON object.")
     parser.add_argument("shape-file", help="Shape file(s) to use. Jobs "
                         "will only be generated where they intersect some "
                         "item from one of these.",
@@ -150,7 +152,6 @@ if __name__ == '__main__':
             total += 1
 
     print "Done, writing new config."
-    conf['regions'] = dict(enumerate(regions))
-
     with open(args['output-file'], 'w') as fh:
-        dump(conf, fh)
+        for r in regions:
+            fh.write(json.dumps(r) + "\n")


### PR DESCRIPTION
First, apologies for the monster patch...

This backs out a lot of the previous work we've done to make Joerd run efficiently while downloading things on the fly and caching as much as possible. Turns out that was A Bad Design for short-lived spot servers.

In place of that, it reverts to an earlier design with two phases: download and render. There are now two `enqueue-` commands, one for each phase, and a single `server` command. The queue has been abstracted, and a `fake` queue type added which executes any "sent" job immediately.

A download job is for a single source file, and will download it from the source and store it in the `source_store`. A render job is for a single output tile, and will download all its dependencies from the `source_store` to the local filesystem, render the job and store that in the `store`. Each job should clean up after itself, meaning that we don't need to track free space any more, but files have to be downloaded fresh each time. In future, we might want to implement some sort of caching in the store layer, but that would have to be carefully written.

On my local system, download jobs vary in length with the source, but are generally under 5 minutes. Render jobs are significantly quicker and vary from a few seconds up to 10s. This finer level of granularity should be a much better fit for spot servers.

Also, now Joerd is single-threaded again. We can run multiple workers per server if there's more than one CPU available, or use smaller servers with lower vCPU.

Connects to #55.

@kevinkreiser, @rmarianski could you review, please?