### PR TITLE
Retry S3 uploads

### DIFF
--- a/joerd/command.py
+++ b/joerd/command.py
@@ -162,7 +162,7 @@ def joerd_enqueue_downloads(cfg):
     for d in downloads:
         # skip any files which already exist.
         if skip_existing and j.source_store.exists(d.output_file()):
-            next
+            continue
 
         data = d.freeze_dry()
         job = dict(job='download', data=data)

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -58,8 +58,6 @@ class S3Store(object):
         return self.bucket
 
     def upload_all(self, d):
-        bucket = self._get_bucket()
-
         # strip trailing slashes so that we're sure that the path we create by
         # removing this as a prefix does not start with a /.
         if not d.endswith('/'):
@@ -86,13 +84,14 @@ class S3Store(object):
 
             # retry up to 6 times, waiting 32 (=2^5) seconds before the final
             # attempt.
-            self.retry_upload_file(bucket, src_name, s3_key, transfer_config,
+            self.retry_upload_file(src_name, s3_key, transfer_config,
                                    extra_args, tries)
 
-    def retry_upload_file(self, bucket, src_name, s3_key, transfer_config,
+    def retry_upload_file(self, src_name, s3_key, transfer_config,
                           extra_args, tries, backoff=1):
         logger = logging.getLogger('s3')
 
+        bucket = self._get_bucket()
         try_num = 0
         while True:
             try:

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -84,6 +84,7 @@ class S3Store(object):
 
             # retry up to 6 times, waiting 32 (=2^5) seconds before the final
             # attempt.
+            tries = 6
             self.retry_upload_file(src_name, s3_key, transfer_config,
                                    extra_args, tries)
 

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -6,6 +6,7 @@ from contextlib2 import contextmanager
 from joerd.tmpdir import tmpdir
 import traceback
 import sys
+import time
 
 
 # extension to mime type mappings to help with serving the S3 bucket as

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -7,6 +7,7 @@ from joerd.tmpdir import tmpdir
 import traceback
 import sys
 import time
+import logging
 
 
 # extension to mime type mappings to help with serving the S3 bucket as

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -91,6 +91,8 @@ class S3Store(object):
 
     def retry_upload_file(self, bucket, src_name, s3_key, transfer_config,
                           extra_args, tries, backoff=1):
+        logger = logging.getLogger('s3')
+
         try_num = 0
         while True:
             try:
@@ -99,8 +101,12 @@ class S3Store(object):
                                    ExtraArgs=extra_args)
                 break
 
-            except StandardError:
+            except StandardError as e:
                 try_num += 1
+                logger.warning("Try %d of %d: Failed to upload %s due to: %s" \
+                               % (try_num, tries, s3_key,
+                                  "".join(traceback.format_exception(
+                                      *sys.exc_info()))))
                 if try_num > tries:
                     raise
 

--- a/logging.example.config
+++ b/logging.example.config
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,srtm,skadi,gmted,etopo1,terrarium,ned,download,process,index,normal,enqueuer,tiff
+keys=root,srtm,skadi,gmted,etopo1,terrarium,ned,download,process,index,normal,enqueuer,tiff,s3
 
 [handlers]
 keys=consoleHandler
@@ -80,6 +80,12 @@ propagate=0
 [logger_enqueuer]
 level=INFO
 qualname=enqueuer
+handlers=consoleHandler
+propagate=0
+
+[logger_s3]
+level=INFO
+qualname=s3
 handlers=consoleHandler
 propagate=0
 


### PR DESCRIPTION
S3 uploads seem to fail very, very rarely in a way that the `boto` library doesn't seem to want to retry. Given that all the processing is done by the time we upload, it seems like a shame to rely on the queue to retry the whole job. Instead, just loop a few times with exponential backoff to see if we can store the tile.

Also, fix typo / keyword error with the functionality to skip existing downloads.

@rmarianski could you review, please?