### PR TITLE
Add simple cache

### DIFF
--- a/joerd/store/cache.py
+++ b/joerd/store/cache.py
@@ -18,7 +18,7 @@ class CacheStore(object):
     def __init__(self, cfg):
         store_type = cfg['store']['type']
         create_fn = plugin('store', store_type, 'create')
-        self.store = create_fn('store', cfg['store'])
+        self.store = create_fn(cfg['store'])
         self.cache_dir = cfg['cache_dir']
 
     def upload_all(self, d):

--- a/joerd/store/cache.py
+++ b/joerd/store/cache.py
@@ -1,0 +1,52 @@
+from joerd.mkdir_p import mkdir_p
+from joerd.plugin import plugin
+from os import link
+import os.path
+
+
+class CacheStore(object):
+    """
+    Every tile that gets generated requires ETOPO1. Rather than re-download
+    it every time (it's 446MB), we cache that file only.
+
+    This is a bit of a hack, and would be better replaced by a generic
+    fixed-size LRU/LFU cache. Even better if the cache could be shared
+    between multiple Joerd processes on the same host.
+    """
+
+    def __init__(self, cfg):
+        create_fn = plugin('store', store_type, 'create')
+        self.store = create_fn('store', cfg['store'])
+        self.cache_dir = cfg['cache_dir']
+
+    def upload_all(self, d):
+        self.store.upload_all(d)
+
+    @contextmanager
+    def upload_dir(self):
+        with tmpdir() as t:
+            yield t
+            self.upload_all(t)
+
+    def exists(self, filename):
+        return self.store.exists(filename)
+
+    def get(self, source, dest):
+        if 'ETOPO1' in source:
+            cache_path = os.path.join(self.cache_dir, source)
+            if not os.path.exists(cache_path):
+                mkdir_p(os.path.dirname(cache_path))
+                self.store.get(source, cache_path)
+
+            # hard link to dest. this makes it non-portable, but means that
+            # we don't have to worry about whether GDAL supports symbolic
+            # links, and we don't have to worry about deleting files, as they
+            # are reference counted by the OS.
+            link(cache_path, dest)
+
+        else:
+            self.store.get(source, dest)
+
+
+def create(cfg):
+    return CacheStore(cfg)

--- a/joerd/store/cache.py
+++ b/joerd/store/cache.py
@@ -7,8 +7,10 @@ import os.path
 
 class CacheStore(object):
     """
-    Every tile that gets generated requires ETOPO1. Rather than re-download
-    it every time (it's 446MB), we cache that file only.
+    Every tile that gets generated requires ETOPO1. And most require a GMTED
+    tile, which are pretty large and cover much of the world. Rather than
+    re-download them every time (ETOPO1 alone is 446MB), we cache ETOPO1 and
+    GMTED.
 
     This is a bit of a hack, and would be better replaced by a generic
     fixed-size LRU/LFU cache. Even better if the cache could be shared
@@ -34,7 +36,7 @@ class CacheStore(object):
         return self.store.exists(filename)
 
     def get(self, source, dest):
-        if 'ETOPO1' in source:
+        if 'ETOPO1' in source or 'gmted' in source:
             cache_path = os.path.join(self.cache_dir, source)
             if not os.path.exists(cache_path):
                 mkdir_p(os.path.dirname(cache_path))

--- a/joerd/store/cache.py
+++ b/joerd/store/cache.py
@@ -1,6 +1,7 @@
 from joerd.mkdir_p import mkdir_p
 from joerd.plugin import plugin
 from os import link
+from contextlib2 import contextmanager
 import os.path
 
 

--- a/joerd/store/cache.py
+++ b/joerd/store/cache.py
@@ -16,6 +16,7 @@ class CacheStore(object):
     """
 
     def __init__(self, cfg):
+        store_type = cfg['store']['type']
         create_fn = plugin('store', store_type, 'create')
         self.store = create_fn('store', cfg['store'])
         self.cache_dir = cfg['cache_dir']


### PR DESCRIPTION
This cache will keep copies of ETOPO1 and GMTED source files on disk. These are the most commonly-used files, and so can provide a significant speed-up to not re-download (measured 2.4x increase in speed).

Current limitations: the cache won't delete files when it is out of space, which may cause problems if there isn't enough free disk space.

@rmarianski could you review, please?