### PR TITLE
Group similar jobs

### DIFF
--- a/joerd/command.py
+++ b/joerd/command.py
@@ -93,7 +93,9 @@ def joerd_enqueue_renders(cfg):
     queue = _make_queue(j, cfg.queue_config)
 
     max_batch_len = 1000
-    size_limit = 256 * 1024
+    # size limit is 256KB for SQS, but we'll leave a little bit of space
+    # just in case there's some small overhead for encoding it as an array.
+    size_limit = 256 * 1024 - 100
     dispatcher = GroupingDispatcher(queue, max_batch_len, logger, size_limit)
 
     for output in j.outputs.itervalues():

--- a/joerd/command.py
+++ b/joerd/command.py
@@ -2,6 +2,7 @@ from config import make_config_from_argparse
 from osgeo import gdal
 from joerd.server import Server
 from joerd.plugin import plugin
+from joerd.dispatcher import Dispatcher, GroupingDispatcher
 import sys
 import argparse
 import os
@@ -57,10 +58,11 @@ def joerd_server(cfg):
 
     while True:
         for message in queue.receive_messages():
-            job = message.body
+            jobs = message.body
 
             try:
-                j.dispatch_job(job)
+                for job in jobs:
+                    j.dispatch_job(job)
 
             except StandardError as e:
                 logger.warning("During processing of job %r, caught "
@@ -90,9 +92,9 @@ def joerd_enqueue_renders(cfg):
     logger.info("Streaming jobs to the queue")
     queue = _make_queue(j, cfg.queue_config)
 
-    batch = []
-    idx = 0
-    next_log_idx = 0
+    max_batch_len = 1000
+    size_limit = 256 * 1024
+    dispatcher = GroupingDispatcher(queue, max_batch_len, logger, size_limit)
 
     for output in j.outputs.itervalues():
         for tile in output.generate_tiles():
@@ -109,33 +111,12 @@ def joerd_enqueue_renders(cfg):
                         sources.append(dict(source=name, vrts=vrts))
 
             assert sources, "Was expecting at least one source for tile %r, " \
-                "but it has none." % tile
+                "but it has none." % tile.tile_name()
 
             job = dict(job='render', data=tile.freeze_dry(), sources=sources)
-            batch.append(job)
-            idx += 1
+            dispatcher.append(job)
 
-            if len(batch) == queue.batch_size():
-                try:
-                    queue.send_messages(batch)
-                except StandardError as e:
-                    logger.warning("Failed to enqueue batch: %s" \
-                                   % "".join(traceback.format_exception(
-                                       *sys.exc_info())))
-                batch = []
-
-            if idx >= next_log_idx:
-                logger.info("Sent %d jobs to queue." % idx)
-                next_log_idx += 1000
-
-    if len(batch) > 0:
-        try:
-            queue.send_messages(batch)
-        except StandardError as e:
-            logger.warning("Failed to enqueue batch: %s" \
-                           % "".join(traceback.format_exception(
-                               *sys.exc_info())))
-
+    dispatcher.flush()
     logger.info("Done.")
 
 
@@ -153,7 +134,10 @@ def joerd_enqueue_downloads(cfg):
     logger.info("Sending %d download jobs to the queue" % len(downloads))
     queue = _make_queue(j, cfg.queue_config)
 
-    batch = []
+    # download jobs are long-running and don't benefit from any cache re-use,
+    # so don't batch them - just one job per batch.
+    max_batch_len = 1
+    dispatcher = Dispatcher(queue, max_batch_len, logger)
 
     # env var to turn on/off skipping existing files. this can be useful when
     # re-running the jobs for a particular area.
@@ -166,25 +150,9 @@ def joerd_enqueue_downloads(cfg):
 
         data = d.freeze_dry()
         job = dict(job='download', data=data)
-        batch.append(job)
+        dispatcher.append(job)
 
-        if len(batch) == queue.batch_size():
-            try:
-                queue.send_messages(batch)
-            except StandardError as e:
-                logger.warning("Failed to enqueue batch: %s" \
-                               % "".join(traceback.format_exception(
-                                   *sys.exc_info())))
-            batch = []
-
-    if len(batch) > 0:
-        try:
-            queue.send_messages(batch)
-        except StandardError as e:
-            logger.warning("Failed to enqueue batch: %s" \
-                           % "".join(traceback.format_exception(
-                               *sys.exc_info())))
-
+    dispatcher.flush()
     logger.info("Done.")
 
 

--- a/joerd/dispatcher.py
+++ b/joerd/dispatcher.py
@@ -1,0 +1,146 @@
+import traceback
+import json
+import sys
+
+
+class Dispatcher(object):
+    """
+    Convenience class to handle queueing up a batch of jobs to the queue
+    and pushing or flushing them when necessary. It also catches and
+    ignores errors.
+    """
+
+    def __init__(self, queue, max_batch_len, logger):
+        self.queue = queue
+        self.max_batch_len = max_batch_len
+        self.logger = logger
+
+        self.batch = self.queue.start_batch(self.max_batch_len)
+        self.idx = 0
+        self.next_log_idx = 0
+
+    def append(self, job):
+        try:
+            self.batch.append(job)
+        except StandardError as e:
+            self.logger.warning("Failed to enqueue batch: %s" \
+                                % "".join(traceback.format_exception(
+                                    *sys.exc_info())))
+
+        self.idx += 1
+        if self.idx >= self.next_log_idx:
+            self.logger.info("Dispatched %d jobs" % self.idx)
+            self.next_log_idx += 1000
+
+    def flush(self):
+        try:
+            self.batch.flush()
+        except StandardError as e:
+            self.logger.warning("Failed to flush batch: %s" \
+                                % "".join(traceback.format_exception(
+                                    *sys.exc_info())))
+
+
+class JSONSizer(object):
+    def __init__(self, sources, limit):
+        self.limit = limit
+        self.data = []
+        self.size = 0
+        fake_job_data = self._job_data(sources)
+        self.initial_size = len(json.dumps(fake_job_data))
+
+    def _job_data(self, sources):
+        return dict(job='renderbatch',
+                    sources=sources,
+                    data=self.data)
+
+    def append(self, sources, data):
+        flushed = None
+        data_size = len(json.dumps(data)) + 1
+
+        assert data_size < self.limit, "Job too large for limit: " \
+            "%d >= %d." % (self.size + 1, self.limit)
+
+        if data_size + self.size > self.limit:
+            flushed = self.flush(sources)
+
+        self.data.append(data)
+        self.size += data_size + 1
+
+        return flushed
+
+    def flush(self, sources):
+        flushed = self._job_data(sources)
+        self.data = []
+        self.size = self.initial_size
+        return flushed
+
+
+def _freeze(obj):
+    if isinstance(obj, dict):
+        frozen_items = [(_freeze(k), _freeze(v)) for (k, v) in obj.items()]
+        return frozenset(frozen_items)
+
+    elif isinstance(obj, list):
+        return tuple([_freeze(item) for item in obj])
+
+    else:
+        return obj
+
+
+def _thaw(obj):
+    if isinstance(obj, frozenset):
+        thawed_items = [(_thaw(k), _thaw(v)) for (k, v) in obj]
+        return dict(thawed_items)
+
+    elif isinstance(obj, tuple):
+        return list([_thaw(item) for item in obj])
+
+    else:
+        return obj
+
+
+class GroupingDispatcher(object):
+    """
+    A dispatcher which groups jobs by the sources that they require. This
+    should help to improve cache re-use.
+    """
+
+    def __init__(self, queue, max_batch_len, logger, size_limit):
+        self.queue = queue
+        self.max_batch_len = max_batch_len
+        self.logger = logger
+        self.limit = size_limit
+
+        self.batches = {}
+        self.dispatcher = Dispatcher(self.queue, self.max_batch_len,
+                                     self.logger)
+
+    def append(self, job):
+        job_typ = job.get('job')
+        sources = job.get('sources')
+
+        if sources and job_typ == 'render':
+            self._append_render_batch(sources, job['data'])
+
+        else:
+            self.dispatcher.append(job)
+
+    def _append_render_batch(self, sources, data):
+        sources_key = _freeze(sources)
+        json_sizer = self.batches.get(sources_key)
+
+        if json_sizer is None:
+            json_sizer = JSONSizer(sources, self.limit)
+            self.batches[sources_key] = json_sizer
+
+        flushed = json_sizer.append(sources, data)
+        if flushed:
+            self.dispatcher.append(flushed)
+
+    def flush(self):
+        for sources_key, json_sizer in self.batches.iteritems():
+            flushed = json_sizer.flush(_thaw(sources_key))
+            self.dispatcher.append(flushed)
+
+        self.dispatcher.flush()

--- a/joerd/dispatcher.py
+++ b/joerd/dispatcher.py
@@ -40,6 +40,8 @@ class Dispatcher(object):
                                 % "".join(traceback.format_exception(
                                     *sys.exc_info())))
 
+        self.logger.info("Dispatcher sent %d jobs in total." % self.idx)
+
 
 class JSONSizer(object):
     def __init__(self, sources, limit):

--- a/joerd/dispatcher.py
+++ b/joerd/dispatcher.py
@@ -43,13 +43,21 @@ class Dispatcher(object):
         self.logger.info("Dispatcher sent %d jobs in total." % self.idx)
 
 
+def _json_dumps(obj):
+    """
+    Convenience method to call json.dumps with a consistent set of (compact)
+    parameters.
+    """
+    return json.dumps(obj, separators=(',',':'))
+
+
 class JSONSizer(object):
     def __init__(self, sources, limit):
         self.limit = limit
         self.data = []
-        self.size = 0
         fake_job_data = self._job_data(sources)
-        self.initial_size = len(json.dumps(fake_job_data))
+        self.initial_size = len(_json_dumps(fake_job_data))
+        self.size = self.initial_size
 
     def _job_data(self, sources):
         return dict(job='renderbatch',
@@ -58,7 +66,7 @@ class JSONSizer(object):
 
     def append(self, sources, data):
         flushed = None
-        data_size = len(json.dumps(data)) + 1
+        data_size = len(_json_dumps(data)) + 1
 
         assert data_size < self.limit, "Job too large for limit: " \
             "%d >= %d." % (self.size + 1, self.limit)
@@ -67,7 +75,7 @@ class JSONSizer(object):
             flushed = self.flush(sources)
 
         self.data.append(data)
-        self.size += data_size + 1
+        self.size += data_size
 
         return flushed
 

--- a/joerd/download.py
+++ b/joerd/download.py
@@ -174,8 +174,8 @@ def options(in_opts={}):
     if backoff == 'exponential':
         out_opts['backoff'] = _exponential_backoff
     else:
-        raise Exception("Configuration backoff=%r not understood."
-                            % backoff)
+        raise NotImplementedError("Configuration backoff=%r not understood."
+                                  % backoff)
 
     timeout = in_opts.get('timeout', 60)
     out_opts['timeout'] = int(timeout)

--- a/joerd/queue/fake.py
+++ b/joerd/queue/fake.py
@@ -39,7 +39,7 @@ class Queue(object):
     def receive_messages(self):
         # fake queue doesn't actually hold any messages, so this is really
         # an error.
-        raise Exception("Fake queue doesn't hold any messages.")
+        raise NotImplementedError("Fake queue doesn't hold any messages.")
 
 
 def create(j, cfg):

--- a/joerd/queue/fake.py
+++ b/joerd/queue/fake.py
@@ -1,3 +1,21 @@
+class Batch(object):
+    """
+    A fake batch, which batches nothing and just sends messages on the
+    queue immediately.
+    """
+
+    def __init__(self, queue, max_batch_len):
+        self.queue = queue
+        # NOTE: this is ignored, and "batches" always contain a single job.
+        self.max_batch_len = max_batch_len
+
+    def append(self, job):
+        self.queue.send_message(job)
+
+    def flush(self):
+        pass
+
+
 class Queue(object):
     """
     A fake queue, which doesn't store or communicate any messages at all, but
@@ -9,12 +27,14 @@ class Queue(object):
     def __init__(self, server):
         self.server = server
 
-    def batch_size(self):
-        return 1
+    def start_batch(self, max_batch_len=1):
+        return Batch(self, max_batch_len)
 
-    def send_messages(self, batch):
-        for msg in batch:
-            self.server.dispatch_job(msg)
+    def send_message(self, msg):
+        self.server.dispatch_job(msg)
+
+    def flush(self):
+        pass
 
     def receive_messages(self):
         # fake queue doesn't actually hold any messages, so this is really

--- a/joerd/queue/sqs.py
+++ b/joerd/queue/sqs.py
@@ -31,7 +31,9 @@ class Batch(object):
         self.batch = []
 
     def append(self, job):
-        job_json = json.dumps(job)
+        # NOTE: using the most compact encoding, as SQS has a size limit on
+        # the payload.
+        job_json = json.dumps(job, separators=(',',':'))
         job_len = len(job_json) + 1
         assert job_len + 1 < self.max_bytes, "Cannot send job of size %d, " \
             "as this job alone is larger than the maximum job size." \

--- a/joerd/queue/sqs.py
+++ b/joerd/queue/sqs.py
@@ -52,7 +52,7 @@ class Batch(object):
 
     def flush(self):
         if len(self.batch) > 0:
-            self.queue.send_message("[" + (",".join(batch)) + "]")
+            self.queue.send_message("[" + (",".join(self.batch)) + "]")
             self.batch = []
             self.batch_size = 2
             self.batch_count = 0

--- a/joerd/queue/sqs.py
+++ b/joerd/queue/sqs.py
@@ -89,7 +89,7 @@ class Queue(object):
         # we still want to take advantage of message batching at the API
         # level, so we do this "second level" of batching.
 
-        entries_too_long = len(entries) + 1 > self.max_batch_len
+        entries_too_long = len(self.entries) + 1 > self.max_batch_len
         entries_too_large = len(job_json) + self.entries_size > \
                             self.max_batch_bytes
 

--- a/joerd/queue/sqs.py
+++ b/joerd/queue/sqs.py
@@ -16,6 +16,48 @@ class Message(object):
         self.msg.delete()
 
 
+class Batch(object):
+    """
+    A batch accumulating jobs and flushing them to the queue when they have
+    reached the maximum serialisation size.
+    """
+
+    def __init__(self, queue, max_bytes, max_len):
+        self.queue = queue
+        self.max_bytes = max_bytes
+        self.max_len = max_len
+        self.batch_count = 0
+        self.batch_size = 2
+        self.batch = []
+
+    def append(self, job):
+        job_json = json.dumps(job)
+        job_len = len(job_json) + 1
+        assert job_len + 1 < self.max_bytes, "Cannot send job of size %d, " \
+            "as this job alone is larger than the maximum job size." \
+            % job_len
+
+        # find out whether, when this job is added to the batch, it will be
+        # either too long or too large. if either, then we must flush the
+        # current batch to make space for this new job.
+        next_batch_too_big = self.batch_size + job_len > self.max_bytes
+        next_batch_too_long = self.batch_count + 1 > self.max_len
+
+        if next_batch_too_big or next_batch_too_long:
+            self.flush()
+
+        self.batch.append(job_json)
+        self.batch_size += job_len
+        self.batch_count += 1
+
+    def flush(self):
+        if len(self.batch) > 0:
+            self.queue.send_message("[" + (",".join(batch)) + "]")
+            self.batch = []
+            self.batch_size = 2
+            self.batch_count = 0
+
+
 class Queue(object):
     """
     A queue which uses SQS behind the scenes to send and receive messages.
@@ -32,20 +74,39 @@ class Queue(object):
         self.sqs = boto3.resource('sqs')
         self.queue = self.sqs.get_queue_by_name(QueueName=queue_name)
         self.idx = 0
+        self.max_batch_bytes = config.get('max_bytes', 256 * 1024)
+        self.max_batch_len = config.get('max_batch_len', 10)
+        self.entries = []
+        self.entries_size = 0
 
-    def batch_size(self):
-        return 10
+    def start_batch(self, max_batch_len):
+        max_batch_len = min(max_batch_len, self.max_batch_len)
+        return Batch(self, self.max_batch_bytes, max_batch_len)
 
-    def send_messages(self, batch):
-        entries = []
-        for job in batch:
-            entries.append(dict(Id=str(self.idx),
-                                MessageBody=json.dumps(job)))
-            self.idx += 1
+    def send_message(self, job_json):
+        # the batching in the Batch class deals with merging together jobs
+        # into arrays of jobs, but sometimes these arrays will be small and
+        # we still want to take advantage of message batching at the API
+        # level, so we do this "second level" of batching.
 
-        result = self.queue.send_messages(Entries=entries)
+        entries_too_long = len(entries) + 1 > self.max_batch_len
+        entries_too_large = len(job_json) + self.entries_size > \
+                            self.max_batch_bytes
+
+        if entries_too_large or entries_too_long:
+            self.flush()
+
+        self.entries.append(dict(Id=str(self.idx), MessageBody=job_json))
+        self.entries_size += len(job_json)
+        self.idx += 1
+
+    def flush(self):
+        result = self.queue.send_messages(Entries=self.entries)
         if 'Failed' in result and result['Failed']:
             raise Exception("Failed to enqueue: %r" % result['Failed'])
+
+        self.entries = []
+        self.entries_size = 0
 
     def receive_messages(self):
         for msg in self.queue.receive_messages():

--- a/joerd/queue/sqs.py
+++ b/joerd/queue/sqs.py
@@ -103,7 +103,7 @@ class Queue(object):
     def flush(self):
         result = self.queue.send_messages(Entries=self.entries)
         if 'Failed' in result and result['Failed']:
-            raise Exception("Failed to enqueue: %r" % result['Failed'])
+            raise RuntimeError("Failed to enqueue: %r" % result['Failed'])
 
         self.entries = []
         self.entries_size = 0

--- a/joerd/source/srtm.py
+++ b/joerd/source/srtm.py
@@ -85,9 +85,9 @@ class SRTMTile(object):
                          os.path.join(target_dir, self.fname))
                 return
 
-            raise Exception("None of the alternative names %r were found "
-                            "in the SRTM zipfile %r. Contents are: %r" %
-                            (names, zip_name, exists))
+            raise LookupError("None of the alternative names %r were found "
+                              "in the SRTM zipfile %r. Contents are: %r" %
+                              (names, zip_name, exists))
 
     def unpack(self, store, data_zip, mask_zip=None):
         with store.upload_dir() as target:

--- a/joerd/store/s3.py
+++ b/joerd/store/s3.py
@@ -145,9 +145,9 @@ class S3Store(object):
             obj = bucket.Object(source)
             obj.download_file(dest)
         except:
-            raise Exception("Failed to download %r, due to: %s"
-                            % (source, "".join(traceback.format_exception(
-                                *sys.exc_info()))))
+            raise RuntimeError("Failed to download %r, due to: %s"
+                               % (source, "".join(traceback.format_exception(
+                                   *sys.exc_info()))))
 
 
 def create(cfg):

--- a/joerd/vrt.py
+++ b/joerd/vrt.py
@@ -19,7 +19,7 @@ def build(files, srs):
         status = subprocess.call(args)
 
         if status != 0:
-            raise Exception("Call to gdalbuildvrt failed: status=%r" % status)
+            raise RuntimeError("Call to gdalbuildvrt failed: status=%r" % status)
 
         ds = gdal.Open(vrt.name)
         yield ds

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,28 @@
+import unittest
+import joerd.dispatcher as dispatcher
+import sys
+
+
+class TestDispatcher(unittest.TestCase):
+
+    def test_freeze(self):
+        examples = [
+            {},
+            [],
+            1,
+            'a',
+            [[]],
+            {'a':{}},
+            {'source': 'ned13', 'vrts': [['ned13/imgn38w123_13.img']]}
+        ]
+
+        for example in examples:
+            k = dispatcher._freeze(example)
+
+            # this will throw if k isn't immutable
+            d = dict()
+            d[k] = None
+
+            # check that the thawed value is the same as the original
+            value = dispatcher._thaw(k)
+            self.assertEqual(example, value)


### PR DESCRIPTION
This adds a new type of job, called "renderbatch", where each job has the same set of sources. This happens frequently with high-zoom tiles and seems to be a good way to enforce re-use. This is done using a `GroupingDispatcher` which maintains a map of the sources to the list of output tiles which share the same set.

Running this on the dev cluster shows a 14x improvement.

Connects to #67.

@rmarianski could you review, please?